### PR TITLE
Implement service layer and controllers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,111 +1,151 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.oscar</groupId>
-	<artifactId>football-api</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>football-api</name>
-	<description>RESTful Football API with Spring Boot.</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.oscar</groupId>
+    <artifactId>football-api</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>football-api</name>
+    <description>RESTful Football API with Spring Boot.</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot Starters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- SpringDoc OpenAPI -->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.9</version>
         </dependency>
+
+        <!-- PostgreSQL -->
         <dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- MapStruct -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- This ensures Lombok and MapStruct work together -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>0.2.0</version>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Environment variables -->
         <dependency>
             <groupId>me.paulschwarz</groupId>
             <artifactId>spring-dotenv</artifactId>
             <version>4.0.0</version>
         </dependency>
-
     </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <!-- Maven Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
 
+            <!-- Spring Boot Maven Plugin -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/oscar/football_api/config/SecurityConfig.java
+++ b/src/main/java/com/oscar/football_api/config/SecurityConfig.java
@@ -1,0 +1,19 @@
+package com.oscar.football_api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // 👈 This disables CSRF
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/oscar/football_api/controller/ClubController.java
+++ b/src/main/java/com/oscar/football_api/controller/ClubController.java
@@ -33,4 +33,9 @@ public class ClubController {
     public ResponseEntity<ClubResponseDTO> getClubById(@PathVariable Long id) {
         return ResponseEntity.ok(clubService.getClubById(id));
     }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ClubResponseDTO> updateClub(@PathVariable Long id, @Valid @RequestBody ClubRequestDTO requestDTO) {
+        return ResponseEntity.ok(clubService.updateClub(id, requestDTO));
+    }
 }

--- a/src/main/java/com/oscar/football_api/controller/ClubController.java
+++ b/src/main/java/com/oscar/football_api/controller/ClubController.java
@@ -38,4 +38,10 @@ public class ClubController {
     public ResponseEntity<ClubResponseDTO> updateClub(@PathVariable Long id, @Valid @RequestBody ClubRequestDTO requestDTO) {
         return ResponseEntity.ok(clubService.updateClub(id, requestDTO));
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteClub(@PathVariable Long id) {
+        clubService.deleteClub(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/oscar/football_api/controller/ClubController.java
+++ b/src/main/java/com/oscar/football_api/controller/ClubController.java
@@ -29,17 +29,17 @@ public class ClubController {
         return ResponseEntity.ok(clubService.getAllClubs());
     }
 
-    @GetMapping("/{id}")
+    @GetMapping(ApiConstant.ID)
     public ResponseEntity<ClubResponseDTO> getClubById(@PathVariable Long id) {
         return ResponseEntity.ok(clubService.getClubById(id));
     }
 
-    @PutMapping("/{id}")
+    @PutMapping(ApiConstant.ID)
     public ResponseEntity<ClubResponseDTO> updateClub(@PathVariable Long id, @Valid @RequestBody ClubRequestDTO requestDTO) {
         return ResponseEntity.ok(clubService.updateClub(id, requestDTO));
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping(ApiConstant.ID)
     public ResponseEntity<Void> deleteClub(@PathVariable Long id) {
         clubService.deleteClub(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/oscar/football_api/controller/ClubController.java
+++ b/src/main/java/com/oscar/football_api/controller/ClubController.java
@@ -8,10 +8,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(ApiConstant.API + ApiConstant.V1 + ApiConstant.CLUBS)
@@ -23,5 +22,15 @@ public class ClubController {
     @PostMapping
     public ResponseEntity<ClubResponseDTO> createClub(@Valid @RequestBody ClubRequestDTO requestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(clubService.createClub(requestDTO));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ClubResponseDTO>> getALlClubs() {
+        return ResponseEntity.ok(clubService.getAllClubs());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ClubResponseDTO> getClubById(@PathVariable Long id) {
+        return ResponseEntity.ok(clubService.getClubById(id));
     }
 }

--- a/src/main/java/com/oscar/football_api/controller/ClubController.java
+++ b/src/main/java/com/oscar/football_api/controller/ClubController.java
@@ -1,0 +1,27 @@
+package com.oscar.football_api.controller;
+
+import com.oscar.football_api.dto.ClubRequestDTO;
+import com.oscar.football_api.dto.response.ClubResponseDTO;
+import com.oscar.football_api.service.ClubService;
+import com.oscar.football_api.utils.ApiConstant;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(ApiConstant.API + ApiConstant.V1 + ApiConstant.CLUBS)
+@RequiredArgsConstructor
+public class ClubController {
+
+    private final ClubService clubService;
+
+    @PostMapping
+    public ResponseEntity<ClubResponseDTO> createClub(@Valid @RequestBody ClubRequestDTO requestDTO) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(clubService.createClub(requestDTO));
+    }
+}

--- a/src/main/java/com/oscar/football_api/controller/ManagerController.java
+++ b/src/main/java/com/oscar/football_api/controller/ManagerController.java
@@ -8,10 +8,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(ApiConstant.API + ApiConstant.V1 + ApiConstant.MANAGERS)
@@ -23,5 +22,15 @@ public class ManagerController {
     @PostMapping
     public ResponseEntity<ManagerResponseDTO> createManager(@Valid @RequestBody ManagerRequestDTO requestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(managerService.createManager(requestDTO));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ManagerResponseDTO>> getAllManagers() {
+        return ResponseEntity.ok(managerService.getAllManagers());
+    }
+
+    @GetMapping(ApiConstant.ID)
+    public ResponseEntity<ManagerResponseDTO> getManagerById(@PathVariable Long id) {
+        return ResponseEntity.ok(managerService.getManagerById(id));
     }
 }

--- a/src/main/java/com/oscar/football_api/controller/ManagerController.java
+++ b/src/main/java/com/oscar/football_api/controller/ManagerController.java
@@ -38,4 +38,10 @@ public class ManagerController {
     public ResponseEntity<ManagerResponseDTO> updateManager(@PathVariable Long id, @Valid @RequestBody ManagerRequestDTO requestDTO) {
         return ResponseEntity.ok(managerService.updateManager(id, requestDTO));
     }
+
+    @DeleteMapping(ApiConstant.ID)
+    public ResponseEntity<Void> deleteManager(@PathVariable Long id) {
+        managerService.deleteManager(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/oscar/football_api/controller/ManagerController.java
+++ b/src/main/java/com/oscar/football_api/controller/ManagerController.java
@@ -33,4 +33,9 @@ public class ManagerController {
     public ResponseEntity<ManagerResponseDTO> getManagerById(@PathVariable Long id) {
         return ResponseEntity.ok(managerService.getManagerById(id));
     }
+
+    @PutMapping(ApiConstant.ID)
+    public ResponseEntity<ManagerResponseDTO> updateManager(@PathVariable Long id, @Valid @RequestBody ManagerRequestDTO requestDTO) {
+        return ResponseEntity.ok(managerService.updateManager(id, requestDTO));
+    }
 }

--- a/src/main/java/com/oscar/football_api/controller/ManagerController.java
+++ b/src/main/java/com/oscar/football_api/controller/ManagerController.java
@@ -1,0 +1,27 @@
+package com.oscar.football_api.controller;
+
+import com.oscar.football_api.dto.ManagerRequestDTO;
+import com.oscar.football_api.dto.response.ManagerResponseDTO;
+import com.oscar.football_api.service.ManagerService;
+import com.oscar.football_api.utils.ApiConstant;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(ApiConstant.API + ApiConstant.V1 + ApiConstant.MANAGERS)
+@RequiredArgsConstructor
+public class ManagerController {
+
+    private final ManagerService managerService;
+
+    @PostMapping
+    public ResponseEntity<ManagerResponseDTO> createManager(@Valid @RequestBody ManagerRequestDTO requestDTO) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(managerService.createManager(requestDTO));
+    }
+}

--- a/src/main/java/com/oscar/football_api/controller/PlayerController.java
+++ b/src/main/java/com/oscar/football_api/controller/PlayerController.java
@@ -38,4 +38,10 @@ public class PlayerController {
     public ResponseEntity<PlayerResponseDTO> updatePlayer(@PathVariable Long id, @Valid @RequestBody PlayerRequestDTO requestDTO) {
         return ResponseEntity.ok(playerService.updatePlayer(id, requestDTO));
     }
+
+    @DeleteMapping(ApiConstant.ID)
+    public ResponseEntity<Void> deletePlayer(@PathVariable Long id) {
+        playerService.deletePlayer(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/oscar/football_api/controller/PlayerController.java
+++ b/src/main/java/com/oscar/football_api/controller/PlayerController.java
@@ -33,4 +33,9 @@ public class PlayerController {
     public ResponseEntity<PlayerResponseDTO> getPlayerById(@PathVariable Long id) {
         return ResponseEntity.ok(playerService.getPlayerById(id));
     }
+
+    @PutMapping(ApiConstant.ID)
+    public ResponseEntity<PlayerResponseDTO> updatePlayer(@PathVariable Long id, @Valid @RequestBody PlayerRequestDTO requestDTO) {
+        return ResponseEntity.ok(playerService.updatePlayer(id, requestDTO));
+    }
 }

--- a/src/main/java/com/oscar/football_api/controller/PlayerController.java
+++ b/src/main/java/com/oscar/football_api/controller/PlayerController.java
@@ -8,10 +8,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(ApiConstant.API + ApiConstant.V1 + ApiConstant.PLAYERS)
@@ -23,5 +22,15 @@ public class PlayerController {
     @PostMapping
     public ResponseEntity<PlayerResponseDTO> createPlayer(@Valid @RequestBody PlayerRequestDTO requestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(playerService.createPlayer(requestDTO));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PlayerResponseDTO>> getAllPlayers() {
+        return ResponseEntity.ok(playerService.getAllPlayers());
+    }
+
+    @GetMapping(ApiConstant.ID)
+    public ResponseEntity<PlayerResponseDTO> getPlayerById(@PathVariable Long id) {
+        return ResponseEntity.ok(playerService.getPlayerById(id));
     }
 }

--- a/src/main/java/com/oscar/football_api/controller/PlayerController.java
+++ b/src/main/java/com/oscar/football_api/controller/PlayerController.java
@@ -1,0 +1,27 @@
+package com.oscar.football_api.controller;
+
+import com.oscar.football_api.dto.PlayerRequestDTO;
+import com.oscar.football_api.dto.response.PlayerResponseDTO;
+import com.oscar.football_api.service.PlayerService;
+import com.oscar.football_api.utils.ApiConstant;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(ApiConstant.API + ApiConstant.V1 + ApiConstant.PLAYERS)
+@RequiredArgsConstructor
+public class PlayerController {
+
+    private final PlayerService playerService;
+
+    @PostMapping
+    public ResponseEntity<PlayerResponseDTO> createPlayer(@Valid @RequestBody PlayerRequestDTO requestDTO) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(playerService.createPlayer(requestDTO));
+    }
+}

--- a/src/main/java/com/oscar/football_api/dto/ClubRequestDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/ClubRequestDTO.java
@@ -1,0 +1,35 @@
+package com.oscar.football_api.dto;
+
+import com.oscar.football_api.entity.enums.League;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubRequestDTO {
+
+    @NotBlank(message = "Club name is required")
+    @Size(max = 50, message = "Club name must not exceed 50 characters")
+    private String name;
+
+    @PastOrPresent(message = "Established date must be in the past or present")
+    private LocalDate establishedDate;
+
+    @NotBlank(message = "Stadium name is required")
+    @Size(max = 50, message = "Stadium name must not exceed 50 characters")
+    private String stadiumName;
+
+    @NotBlank(message = "City is required")
+    @Size(max = 50, message = "City name must not exceed 50 characters")
+    private String city;
+
+    @NotNull(message = "League is required")
+    private League league;
+
+    @Min(value = 0, message = "Titles won must not be negative")
+    private int titlesWon;
+}

--- a/src/main/java/com/oscar/football_api/dto/ManagerRequestDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/ManagerRequestDTO.java
@@ -1,0 +1,33 @@
+package com.oscar.football_api.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ManagerRequestDTO {
+
+    @NotBlank(message = "Manager name is required")
+    @Size(max = 50, message = "Manager name must not exceed 50 characters")
+    private String name;
+
+    @NotBlank(message = "Nationality is required")
+    @Size(max = 50, message = "Nationality must not exceed 50 characters")
+    private String nationality;
+
+    @Past(message = "Date of birth must be in the past")
+    private LocalDate dateOfBirth;
+
+    @Min(value = 0, message = "Titles won must not be negative")
+    private int titlesWon;
+
+    @NotNull(message = "Club id is required")
+    private Long clubId;
+}

--- a/src/main/java/com/oscar/football_api/dto/PlayerRequestDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/PlayerRequestDTO.java
@@ -1,0 +1,35 @@
+package com.oscar.football_api.dto;
+
+import com.oscar.football_api.entity.enums.Position;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlayerRequestDTO {
+
+    @NotBlank(message = "Name is required")
+    @Size(max = 50, message = "Name must be at most 50 characters")
+    private String name;
+
+    @NotNull(message = "Position is required")
+    private Position position;
+
+    @Min(value = 1, message = "Jersey number must be between 1 and 99")
+    @Max(value = 99, message = "Jersey number must be between 1 and 99")
+    private int jerseyNumber;
+
+    @Past(message = "Date of birth must be in the past")
+    private LocalDate dateOfBirth;
+
+    @NotBlank(message = "Nationality is required")
+    @Size(max = 50, message = "Nationality must be at most 50 characters")
+    private String nationality;
+
+    @NotNull(message = "Club ID is required")
+    private Long clubId;
+}

--- a/src/main/java/com/oscar/football_api/dto/response/ClubResponseDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/response/ClubResponseDTO.java
@@ -1,0 +1,28 @@
+package com.oscar.football_api.dto.response;
+
+import com.oscar.football_api.entity.enums.League;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubResponseDTO {
+
+    private Long id;
+    private String name;
+    private LocalDate establishedDate;
+    private String stadiumName;
+    private String city;
+    private League league;
+    private int titlesWon;
+
+    private List<PlayerResponseDTO> players;
+    private ManagerResponseDTO manager;
+}

--- a/src/main/java/com/oscar/football_api/dto/response/ManagerResponseDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/response/ManagerResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -14,5 +16,7 @@ public class ManagerResponseDTO {
     private Long id;
     private String name;
     private String nationality;
+    private LocalDate dateOfBirth;
     private int titlesWon;
+    private Long clubId;
 }

--- a/src/main/java/com/oscar/football_api/dto/response/ManagerResponseDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/response/ManagerResponseDTO.java
@@ -1,0 +1,18 @@
+package com.oscar.football_api.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ManagerResponseDTO {
+
+    private Long id;
+    private String name;
+    private String nationality;
+    private int titlesWon;
+}

--- a/src/main/java/com/oscar/football_api/dto/response/PlayerResponseDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/response/PlayerResponseDTO.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,5 +18,7 @@ public class PlayerResponseDTO {
     private String name;
     private Position position;
     private int jerseyNumber;
+    private LocalDate dateOfBirth;
     private String nationality;
+    private Long clubId;
 }

--- a/src/main/java/com/oscar/football_api/dto/response/PlayerResponseDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/response/PlayerResponseDTO.java
@@ -1,0 +1,20 @@
+package com.oscar.football_api.dto.response;
+
+import com.oscar.football_api.entity.enums.Position;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlayerResponseDTO {
+
+    private Long id;
+    private String name;
+    private Position position;
+    private int jerseyNumber;
+    private String nationality;
+}

--- a/src/main/java/com/oscar/football_api/entity/Manager.java
+++ b/src/main/java/com/oscar/football_api/entity/Manager.java
@@ -33,6 +33,6 @@ public class Manager {
     private int titlesWon;
 
     @OneToOne
-    @JoinColumn(name = "club_id", nullable = false)
+    @JoinColumn(name = "club_id", unique = true, nullable = false)
     private Club club;
 }

--- a/src/main/java/com/oscar/football_api/mapper/ClubMapper.java
+++ b/src/main/java/com/oscar/football_api/mapper/ClubMapper.java
@@ -1,0 +1,13 @@
+package com.oscar.football_api.mapper;
+
+import com.oscar.football_api.dto.ClubRequestDTO;
+import com.oscar.football_api.dto.response.ClubResponseDTO;
+import com.oscar.football_api.entity.Club;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ClubMapper {
+
+    Club toEntity(ClubRequestDTO dto);
+    ClubResponseDTO toDTO(Club club);
+}

--- a/src/main/java/com/oscar/football_api/mapper/ClubMapper.java
+++ b/src/main/java/com/oscar/football_api/mapper/ClubMapper.java
@@ -5,9 +5,10 @@ import com.oscar.football_api.dto.response.ClubResponseDTO;
 import com.oscar.football_api.entity.Club;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {ManagerMapper.class})
 public interface ClubMapper {
 
     Club toEntity(ClubRequestDTO dto);
+
     ClubResponseDTO toDTO(Club club);
 }

--- a/src/main/java/com/oscar/football_api/mapper/ClubMapper.java
+++ b/src/main/java/com/oscar/football_api/mapper/ClubMapper.java
@@ -5,7 +5,7 @@ import com.oscar.football_api.dto.response.ClubResponseDTO;
 import com.oscar.football_api.entity.Club;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring", uses = {ManagerMapper.class})
+@Mapper(componentModel = "spring", uses = {ManagerMapper.class, PlayerMapper.class})
 public interface ClubMapper {
 
     Club toEntity(ClubRequestDTO dto);

--- a/src/main/java/com/oscar/football_api/mapper/ManagerMapper.java
+++ b/src/main/java/com/oscar/football_api/mapper/ManagerMapper.java
@@ -1,0 +1,17 @@
+package com.oscar.football_api.mapper;
+
+import com.oscar.football_api.dto.ManagerRequestDTO;
+import com.oscar.football_api.dto.response.ManagerResponseDTO;
+import com.oscar.football_api.entity.Manager;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ManagerMapper {
+
+    @Mapping(source = "clubId", target = "club.id")
+    Manager toEntity(ManagerRequestDTO dto);
+
+    @Mapping(source = "club.id", target = "clubId")
+    ManagerResponseDTO toDTO(Manager manager);
+}

--- a/src/main/java/com/oscar/football_api/mapper/PlayerMapper.java
+++ b/src/main/java/com/oscar/football_api/mapper/PlayerMapper.java
@@ -1,0 +1,17 @@
+package com.oscar.football_api.mapper;
+
+import com.oscar.football_api.dto.PlayerRequestDTO;
+import com.oscar.football_api.dto.response.PlayerResponseDTO;
+import com.oscar.football_api.entity.Player;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface PlayerMapper {
+
+    @Mapping(source = "clubId", target = "club.id")
+    Player toEntity(PlayerRequestDTO dto);
+
+    @Mapping(source = "club.id", target = "clubId")
+    PlayerResponseDTO toDTO(Player player);
+}

--- a/src/main/java/com/oscar/football_api/repository/PlayerRepository.java
+++ b/src/main/java/com/oscar/football_api/repository/PlayerRepository.java
@@ -4,6 +4,10 @@ import com.oscar.football_api.entity.Player;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PlayerRepository extends JpaRepository<Player, Long> {
+
+    Optional<Player> findByClubIdAndJerseyNumber(Long clubId, int jerseyNumber);
 }

--- a/src/main/java/com/oscar/football_api/service/ClubService.java
+++ b/src/main/java/com/oscar/football_api/service/ClubService.java
@@ -11,4 +11,5 @@ public interface ClubService {
     List<ClubResponseDTO> getAllClubs();
     ClubResponseDTO getClubById(Long id);
     ClubResponseDTO updateClub(Long id, ClubRequestDTO requestDTO);
+    void deleteClub(Long id);
 }

--- a/src/main/java/com/oscar/football_api/service/ClubService.java
+++ b/src/main/java/com/oscar/football_api/service/ClubService.java
@@ -3,7 +3,11 @@ package com.oscar.football_api.service;
 import com.oscar.football_api.dto.ClubRequestDTO;
 import com.oscar.football_api.dto.response.ClubResponseDTO;
 
+import java.util.List;
+
 public interface ClubService {
 
     ClubResponseDTO createClub(ClubRequestDTO requestDTO);
+    List<ClubResponseDTO> getAllClubs();
+    ClubResponseDTO getClubById(Long id);
 }

--- a/src/main/java/com/oscar/football_api/service/ClubService.java
+++ b/src/main/java/com/oscar/football_api/service/ClubService.java
@@ -10,4 +10,5 @@ public interface ClubService {
     ClubResponseDTO createClub(ClubRequestDTO requestDTO);
     List<ClubResponseDTO> getAllClubs();
     ClubResponseDTO getClubById(Long id);
+    ClubResponseDTO updateClub(Long id, ClubRequestDTO requestDTO);
 }

--- a/src/main/java/com/oscar/football_api/service/ClubService.java
+++ b/src/main/java/com/oscar/football_api/service/ClubService.java
@@ -1,0 +1,9 @@
+package com.oscar.football_api.service;
+
+import com.oscar.football_api.dto.ClubRequestDTO;
+import com.oscar.football_api.dto.response.ClubResponseDTO;
+
+public interface ClubService {
+
+    ClubResponseDTO createClub(ClubRequestDTO requestDTO);
+}

--- a/src/main/java/com/oscar/football_api/service/ManagerService.java
+++ b/src/main/java/com/oscar/football_api/service/ManagerService.java
@@ -3,7 +3,11 @@ package com.oscar.football_api.service;
 import com.oscar.football_api.dto.ManagerRequestDTO;
 import com.oscar.football_api.dto.response.ManagerResponseDTO;
 
+import java.util.List;
+
 public interface ManagerService {
 
     ManagerResponseDTO createManager(ManagerRequestDTO requestDTO);
+    List<ManagerResponseDTO> getAllManagers();
+    ManagerResponseDTO getManagerById(Long id);
 }

--- a/src/main/java/com/oscar/football_api/service/ManagerService.java
+++ b/src/main/java/com/oscar/football_api/service/ManagerService.java
@@ -11,4 +11,5 @@ public interface ManagerService {
     List<ManagerResponseDTO> getAllManagers();
     ManagerResponseDTO getManagerById(Long id);
     ManagerResponseDTO updateManager(Long id, ManagerRequestDTO requestDTO);
+    void deleteManager(Long id);
 }

--- a/src/main/java/com/oscar/football_api/service/ManagerService.java
+++ b/src/main/java/com/oscar/football_api/service/ManagerService.java
@@ -1,0 +1,9 @@
+package com.oscar.football_api.service;
+
+import com.oscar.football_api.dto.ManagerRequestDTO;
+import com.oscar.football_api.dto.response.ManagerResponseDTO;
+
+public interface ManagerService {
+
+    ManagerResponseDTO createManager(ManagerRequestDTO requestDTO);
+}

--- a/src/main/java/com/oscar/football_api/service/ManagerService.java
+++ b/src/main/java/com/oscar/football_api/service/ManagerService.java
@@ -10,4 +10,5 @@ public interface ManagerService {
     ManagerResponseDTO createManager(ManagerRequestDTO requestDTO);
     List<ManagerResponseDTO> getAllManagers();
     ManagerResponseDTO getManagerById(Long id);
+    ManagerResponseDTO updateManager(Long id, ManagerRequestDTO requestDTO);
 }

--- a/src/main/java/com/oscar/football_api/service/PlayerService.java
+++ b/src/main/java/com/oscar/football_api/service/PlayerService.java
@@ -3,7 +3,11 @@ package com.oscar.football_api.service;
 import com.oscar.football_api.dto.PlayerRequestDTO;
 import com.oscar.football_api.dto.response.PlayerResponseDTO;
 
+import java.util.List;
+
 public interface PlayerService {
 
     PlayerResponseDTO createPlayer(PlayerRequestDTO requestDTO);
+    List<PlayerResponseDTO> getAllPlayers();
+    PlayerResponseDTO getPlayerById(Long id);
 }

--- a/src/main/java/com/oscar/football_api/service/PlayerService.java
+++ b/src/main/java/com/oscar/football_api/service/PlayerService.java
@@ -10,4 +10,5 @@ public interface PlayerService {
     PlayerResponseDTO createPlayer(PlayerRequestDTO requestDTO);
     List<PlayerResponseDTO> getAllPlayers();
     PlayerResponseDTO getPlayerById(Long id);
+    PlayerResponseDTO updatePlayer(Long id, PlayerRequestDTO requestDTO);
 }

--- a/src/main/java/com/oscar/football_api/service/PlayerService.java
+++ b/src/main/java/com/oscar/football_api/service/PlayerService.java
@@ -1,0 +1,9 @@
+package com.oscar.football_api.service;
+
+import com.oscar.football_api.dto.PlayerRequestDTO;
+import com.oscar.football_api.dto.response.PlayerResponseDTO;
+
+public interface PlayerService {
+
+    PlayerResponseDTO createPlayer(PlayerRequestDTO requestDTO);
+}

--- a/src/main/java/com/oscar/football_api/service/PlayerService.java
+++ b/src/main/java/com/oscar/football_api/service/PlayerService.java
@@ -11,4 +11,5 @@ public interface PlayerService {
     List<PlayerResponseDTO> getAllPlayers();
     PlayerResponseDTO getPlayerById(Long id);
     PlayerResponseDTO updatePlayer(Long id, PlayerRequestDTO requestDTO);
+    void deletePlayer(Long id);
 }

--- a/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
@@ -38,4 +38,19 @@ public class ClubServiceImpl implements ClubService {
         return clubMapper.toDTO(club);
     }
 
+    public ClubResponseDTO updateClub(Long id, ClubRequestDTO requestDTO) {
+        Club club = clubRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Club not found."));
+
+        club.setName(requestDTO.getName());
+        club.setEstablishedDate(requestDTO.getEstablishedDate());
+        club.setStadiumName(requestDTO.getStadiumName());
+        club.setCity(requestDTO.getCity());
+        club.setLeague(requestDTO.getLeague());
+        club.setTitlesWon(requestDTO.getTitlesWon());
+
+        Club updated = clubRepository.save(club);
+        return clubMapper.toDTO(updated);
+    }
+
 }

--- a/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
@@ -1,0 +1,25 @@
+package com.oscar.football_api.service.impl;
+
+import com.oscar.football_api.dto.ClubRequestDTO;
+import com.oscar.football_api.dto.response.ClubResponseDTO;
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.mapper.ClubMapper;
+import com.oscar.football_api.repository.ClubRepository;
+import com.oscar.football_api.service.ClubService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ClubServiceImpl implements ClubService {
+
+    private final ClubRepository clubRepository;
+    private final ClubMapper clubMapper;
+
+    public ClubResponseDTO createClub(ClubRequestDTO requestDTO) {
+        Club club = clubMapper.toEntity(requestDTO);
+        Club saved = clubRepository.save(club);
+        return clubMapper.toDTO(saved);
+    }
+
+}

--- a/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
@@ -53,4 +53,10 @@ public class ClubServiceImpl implements ClubService {
         return clubMapper.toDTO(updated);
     }
 
+    public void deleteClub(Long id) {
+        Club club = clubRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Club not found."));
+        clubRepository.delete(club);
+    }
+
 }

--- a/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
@@ -6,6 +6,7 @@ import com.oscar.football_api.entity.Club;
 import com.oscar.football_api.mapper.ClubMapper;
 import com.oscar.football_api.repository.ClubRepository;
 import com.oscar.football_api.service.ClubService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +15,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ClubServiceImpl implements ClubService {
 
     private final ClubRepository clubRepository;

--- a/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
@@ -9,6 +9,9 @@ import com.oscar.football_api.service.ClubService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ClubServiceImpl implements ClubService {
@@ -20,6 +23,19 @@ public class ClubServiceImpl implements ClubService {
         Club club = clubMapper.toEntity(requestDTO);
         Club saved = clubRepository.save(club);
         return clubMapper.toDTO(saved);
+    }
+
+    public List<ClubResponseDTO> getAllClubs() {
+        return clubRepository.findAll()
+                .stream()
+                .map(clubMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public ClubResponseDTO getClubById(Long id) {
+        Club club = clubRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Club not found."));
+        return clubMapper.toDTO(club);
     }
 
 }

--- a/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
@@ -51,4 +51,21 @@ public class ManagerServiceImpl implements ManagerService {
                 .orElseThrow(() -> new RuntimeException("Manager not found."));
         return managerMapper.toDTO(manager);
     }
+
+    public ManagerResponseDTO updateManager(Long id, ManagerRequestDTO requestDTO) {
+        Manager manager = managerRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Manager not found."));
+
+        if (!manager.getClub().getId().equals(requestDTO.getClubId())) {
+            throw new RuntimeException("Cannot change manager's club. Delete and create a new manager instead.");
+        }
+
+        manager.setName(requestDTO.getName());
+        manager.setNationality(requestDTO.getNationality());
+        manager.setDateOfBirth(requestDTO.getDateOfBirth());
+        manager.setTitlesWon(requestDTO.getTitlesWon());
+
+        Manager updated = managerRepository.save(manager);
+        return managerMapper.toDTO(updated);
+    }
 }

--- a/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
@@ -1,0 +1,38 @@
+package com.oscar.football_api.service.impl;
+
+import com.oscar.football_api.dto.ManagerRequestDTO;
+import com.oscar.football_api.dto.response.ManagerResponseDTO;
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.Manager;
+import com.oscar.football_api.mapper.ManagerMapper;
+import com.oscar.football_api.repository.ClubRepository;
+import com.oscar.football_api.repository.ManagerRepository;
+import com.oscar.football_api.service.ManagerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerServiceImpl implements ManagerService {
+
+    private final ManagerRepository managerRepository;
+    private final ClubRepository clubRepository;
+    private final ManagerMapper managerMapper;
+
+    public ManagerResponseDTO createManager(ManagerRequestDTO requestDTO) {
+        Club club = clubRepository.findById(requestDTO.getClubId())
+                .orElseThrow(() -> new RuntimeException("Club not found."));
+
+        if (club.getManager() != null) {
+            throw new RuntimeException("This club already has a manager assigned.");
+        }
+
+        Manager manager = managerMapper.toEntity(requestDTO);
+        manager.setClub(club);
+
+        Manager saved = managerRepository.save(manager);
+        club.setManager(saved);
+
+        return managerMapper.toDTO(saved);
+    }
+}

--- a/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
@@ -11,6 +11,9 @@ import com.oscar.football_api.service.ManagerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ManagerServiceImpl implements ManagerService {
@@ -34,5 +37,18 @@ public class ManagerServiceImpl implements ManagerService {
         club.setManager(saved);
 
         return managerMapper.toDTO(saved);
+    }
+
+    public List<ManagerResponseDTO> getAllManagers() {
+        return managerRepository.findAll()
+                .stream()
+                .map(managerMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public ManagerResponseDTO getManagerById(Long id) {
+        Manager manager = managerRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Manager not found."));
+        return managerMapper.toDTO(manager);
     }
 }

--- a/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
@@ -8,6 +8,7 @@ import com.oscar.football_api.mapper.ManagerMapper;
 import com.oscar.football_api.repository.ClubRepository;
 import com.oscar.football_api.repository.ManagerRepository;
 import com.oscar.football_api.service.ManagerService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ManagerServiceImpl implements ManagerService {
 
     private final ManagerRepository managerRepository;
@@ -35,6 +37,7 @@ public class ManagerServiceImpl implements ManagerService {
 
         Manager saved = managerRepository.save(manager);
         club.setManager(saved);
+        clubRepository.save(club);
 
         return managerMapper.toDTO(saved);
     }
@@ -67,5 +70,19 @@ public class ManagerServiceImpl implements ManagerService {
 
         Manager updated = managerRepository.save(manager);
         return managerMapper.toDTO(updated);
+    }
+
+    public void deleteManager(Long id) {
+        Manager manager = managerRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Manager not found."));
+
+        Club club = manager.getClub();
+        if (club != null) {
+            club.setManager(null);
+            clubRepository.save(club);
+            manager.setClub(null);
+        }
+
+        managerRepository.delete(manager);
     }
 }

--- a/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
@@ -1,0 +1,39 @@
+package com.oscar.football_api.service.impl;
+
+import com.oscar.football_api.dto.PlayerRequestDTO;
+import com.oscar.football_api.dto.response.PlayerResponseDTO;
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.Player;
+import com.oscar.football_api.mapper.PlayerMapper;
+import com.oscar.football_api.repository.ClubRepository;
+import com.oscar.football_api.repository.PlayerRepository;
+import com.oscar.football_api.service.PlayerService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlayerServiceImpl implements PlayerService {
+
+    private final PlayerRepository playerRepository;
+    private final ClubRepository clubRepository;
+    private final PlayerMapper playerMapper;
+
+    public PlayerResponseDTO createPlayer(PlayerRequestDTO requestDTO) {
+        Club club = clubRepository.findById(requestDTO.getClubId())
+                .orElseThrow(() -> new RuntimeException("Club not found."));
+
+        playerRepository.findByClubIdAndJerseyNumber(club.getId(), requestDTO.getJerseyNumber())
+                .ifPresent(p -> {
+                    throw new RuntimeException("Jersey number " + requestDTO.getJerseyNumber() + " is already taken in this club");
+                });
+
+        Player player = playerMapper.toEntity(requestDTO);
+        player.setClub(club);
+
+        Player saved = playerRepository.save(player);
+        return playerMapper.toDTO(saved);
+    }
+}

--- a/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
@@ -54,4 +54,30 @@ public class PlayerServiceImpl implements PlayerService {
                 .orElseThrow(() -> new RuntimeException("Player not found."));
         return playerMapper.toDTO(player);
     }
+
+    public PlayerResponseDTO updatePlayer(Long id, PlayerRequestDTO requestDTO) {
+        Player player = playerRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Player not found."));
+
+        Club club = clubRepository.findById(requestDTO.getClubId())
+                .orElseThrow(() -> new RuntimeException("Club not found."));
+
+        playerRepository.findByClubIdAndJerseyNumber(club.getId(), requestDTO.getJerseyNumber())
+                .ifPresent(existing -> {
+                    if (!existing.getId().equals(id)) {
+                        throw new RuntimeException("Jersey number already taken in this club");
+                    }
+                });
+
+
+        player.setName(requestDTO.getName());
+        player.setPosition(requestDTO.getPosition());
+        player.setJerseyNumber(requestDTO.getJerseyNumber());
+        player.setDateOfBirth(requestDTO.getDateOfBirth());
+        player.setNationality(requestDTO.getNationality());
+        player.setClub(club);
+
+        return playerMapper.toDTO(playerRepository.save(player));
+    }
+
 }

--- a/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
@@ -1,8 +1,10 @@
 package com.oscar.football_api.service.impl;
 
 import com.oscar.football_api.dto.PlayerRequestDTO;
+import com.oscar.football_api.dto.response.ManagerResponseDTO;
 import com.oscar.football_api.dto.response.PlayerResponseDTO;
 import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.Manager;
 import com.oscar.football_api.entity.Player;
 import com.oscar.football_api.mapper.PlayerMapper;
 import com.oscar.football_api.repository.ClubRepository;
@@ -11,6 +13,9 @@ import com.oscar.football_api.service.PlayerService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +40,18 @@ public class PlayerServiceImpl implements PlayerService {
 
         Player saved = playerRepository.save(player);
         return playerMapper.toDTO(saved);
+    }
+
+    public List<PlayerResponseDTO> getAllPlayers() {
+        return playerRepository.findAll()
+                .stream()
+                .map(playerMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public PlayerResponseDTO getPlayerById(Long id) {
+        Player player = playerRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Player not found."));
+        return playerMapper.toDTO(player);
     }
 }

--- a/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
@@ -80,4 +80,9 @@ public class PlayerServiceImpl implements PlayerService {
         return playerMapper.toDTO(playerRepository.save(player));
     }
 
+    public void deletePlayer(Long id) {
+        Player player = playerRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Player not found."));
+        playerRepository.delete(player);
+    }
 }

--- a/src/main/java/com/oscar/football_api/utils/ApiConstant.java
+++ b/src/main/java/com/oscar/football_api/utils/ApiConstant.java
@@ -1,0 +1,14 @@
+package com.oscar.football_api.utils;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ApiConstant {
+
+    public static final String API = "/api";
+    public static final String V1 = "/v1";
+    public static final String CLUBS = "/clubs";
+    public static final String PLAYERS = "/players";
+    public static final String MANAGERS = "/managers";
+
+}

--- a/src/main/java/com/oscar/football_api/utils/ApiConstant.java
+++ b/src/main/java/com/oscar/football_api/utils/ApiConstant.java
@@ -10,5 +10,6 @@ public class ApiConstant {
     public static final String CLUBS = "/clubs";
     public static final String PLAYERS = "/players";
     public static final String MANAGERS = "/managers";
+    public static final String ID = "/{id}";
 
 }


### PR DESCRIPTION
This PR adds services and controllers for Club, Manager, and Player entities, implementing full CRUD operations with request/response DTOs and mappers.
All endpoints were manually tested end-to-end using Postman.

**Changes Included**

**Security**
- Configured SecurityConfig to disable CSRF and allow all requests for Postman testing.

**Project Setup**

- Refactored pom.xml for readability.
- Added MapStruct and updated Lombok for compatibility.
- Introduced ApiConstant for consistent constant usage.

**Club**

- Added ClubRequestDTO and ClubResponseDTO.
- Implemented ClubMapper for entity–DTO conversions.
- Created ClubService and ClubServiceImpl with full CRUD logic.
- Added endpoints in ClubController: create, getAll, getById, update, delete.

**Manager**

- Added ManagerRequestDTO and extended ManagerResponseDTO.
- Implemented ManagerMapper.
- Created ManagerService and ManagerServiceImpl with CRUD logic.
- Added endpoints in ManagerController: create, getAll, getById, update, delete.
- Fixed null issue when retrieving Managers with Clubs.

**Player**

- Added PlayerRequestDTO and PlayerResponseDTO.
- Implemented PlayerMapper and added @Mapper to ClubMapper.
- Created PlayerService and PlayerServiceImpl with CRUD logic.
- Added endpoints in PlayerController: create, getAll, getById, update, delete.
- Added custom repository method: findByClubIdAndJerseyNumber.

**Testing**

- Verified all CRUD flows (Club, Manager, Player) via Postman requests.
- Confirmed DTO mapping and persistence layer behavior.

**Issue**
Closes #8