### PR TITLE
Add Swagger/OpenApi documentation

### DIFF
--- a/src/main/java/com/oscar/football_api/config/OpenApiConfig.java
+++ b/src/main/java/com/oscar/football_api/config/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.oscar.football_api.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Football API")
+                        .version("1.0")
+                        .description("API for managing clubs, players, and managers"));
+    }
+}

--- a/src/main/java/com/oscar/football_api/controller/ClubController.java
+++ b/src/main/java/com/oscar/football_api/controller/ClubController.java
@@ -4,6 +4,8 @@ import com.oscar.football_api.dto.ClubRequestDTO;
 import com.oscar.football_api.dto.response.ClubResponseDTO;
 import com.oscar.football_api.service.ClubService;
 import com.oscar.football_api.utils.ApiConstant;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,31 +17,38 @@ import java.util.List;
 @RestController
 @RequestMapping(ApiConstant.API + ApiConstant.V1 + ApiConstant.CLUBS)
 @RequiredArgsConstructor
+@Tag(name = "Clubs", description = "Endpoints for club management")
+
 public class ClubController {
 
     private final ClubService clubService;
 
     @PostMapping
+    @Operation(summary = "Create a new club")
     public ResponseEntity<ClubResponseDTO> createClub(@Valid @RequestBody ClubRequestDTO requestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(clubService.createClub(requestDTO));
     }
 
     @GetMapping
+    @Operation(summary = "Get all clubs")
     public ResponseEntity<List<ClubResponseDTO>> getALlClubs() {
         return ResponseEntity.ok(clubService.getAllClubs());
     }
 
     @GetMapping(ApiConstant.ID)
+    @Operation(summary = "Get one club")
     public ResponseEntity<ClubResponseDTO> getClubById(@PathVariable Long id) {
         return ResponseEntity.ok(clubService.getClubById(id));
     }
 
     @PutMapping(ApiConstant.ID)
+    @Operation(summary = "Update a club")
     public ResponseEntity<ClubResponseDTO> updateClub(@PathVariable Long id, @Valid @RequestBody ClubRequestDTO requestDTO) {
         return ResponseEntity.ok(clubService.updateClub(id, requestDTO));
     }
 
     @DeleteMapping(ApiConstant.ID)
+    @Operation(summary = "Delete a club")
     public ResponseEntity<Void> deleteClub(@PathVariable Long id) {
         clubService.deleteClub(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/oscar/football_api/controller/ManagerController.java
+++ b/src/main/java/com/oscar/football_api/controller/ManagerController.java
@@ -4,6 +4,8 @@ import com.oscar.football_api.dto.ManagerRequestDTO;
 import com.oscar.football_api.dto.response.ManagerResponseDTO;
 import com.oscar.football_api.service.ManagerService;
 import com.oscar.football_api.utils.ApiConstant;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,31 +17,37 @@ import java.util.List;
 @RestController
 @RequestMapping(ApiConstant.API + ApiConstant.V1 + ApiConstant.MANAGERS)
 @RequiredArgsConstructor
+@Tag(name = "Managers", description = "Endpoints for manager management")
 public class ManagerController {
 
     private final ManagerService managerService;
 
     @PostMapping
+    @Operation(summary = "Create a new manager")
     public ResponseEntity<ManagerResponseDTO> createManager(@Valid @RequestBody ManagerRequestDTO requestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(managerService.createManager(requestDTO));
     }
 
     @GetMapping
+    @Operation(summary = "Get all managers")
     public ResponseEntity<List<ManagerResponseDTO>> getAllManagers() {
         return ResponseEntity.ok(managerService.getAllManagers());
     }
 
     @GetMapping(ApiConstant.ID)
+    @Operation(summary = "Get one manager")
     public ResponseEntity<ManagerResponseDTO> getManagerById(@PathVariable Long id) {
         return ResponseEntity.ok(managerService.getManagerById(id));
     }
 
     @PutMapping(ApiConstant.ID)
+    @Operation(summary = "Update a manager")
     public ResponseEntity<ManagerResponseDTO> updateManager(@PathVariable Long id, @Valid @RequestBody ManagerRequestDTO requestDTO) {
         return ResponseEntity.ok(managerService.updateManager(id, requestDTO));
     }
 
     @DeleteMapping(ApiConstant.ID)
+    @Operation(summary = "Delete a manager")
     public ResponseEntity<Void> deleteManager(@PathVariable Long id) {
         managerService.deleteManager(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/oscar/football_api/controller/PlayerController.java
+++ b/src/main/java/com/oscar/football_api/controller/PlayerController.java
@@ -4,6 +4,8 @@ import com.oscar.football_api.dto.PlayerRequestDTO;
 import com.oscar.football_api.dto.response.PlayerResponseDTO;
 import com.oscar.football_api.service.PlayerService;
 import com.oscar.football_api.utils.ApiConstant;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,31 +17,37 @@ import java.util.List;
 @RestController
 @RequestMapping(ApiConstant.API + ApiConstant.V1 + ApiConstant.PLAYERS)
 @RequiredArgsConstructor
+@Tag(name = "Players", description = "Endpoints for player management")
 public class PlayerController {
 
     private final PlayerService playerService;
 
     @PostMapping
+    @Operation(summary = "Create a new player")
     public ResponseEntity<PlayerResponseDTO> createPlayer(@Valid @RequestBody PlayerRequestDTO requestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(playerService.createPlayer(requestDTO));
     }
 
     @GetMapping
+    @Operation(summary = "Get all players")
     public ResponseEntity<List<PlayerResponseDTO>> getAllPlayers() {
         return ResponseEntity.ok(playerService.getAllPlayers());
     }
 
     @GetMapping(ApiConstant.ID)
+    @Operation(summary = "Get one player")
     public ResponseEntity<PlayerResponseDTO> getPlayerById(@PathVariable Long id) {
         return ResponseEntity.ok(playerService.getPlayerById(id));
     }
 
     @PutMapping(ApiConstant.ID)
+    @Operation(summary = "Update a player")
     public ResponseEntity<PlayerResponseDTO> updatePlayer(@PathVariable Long id, @Valid @RequestBody PlayerRequestDTO requestDTO) {
         return ResponseEntity.ok(playerService.updatePlayer(id, requestDTO));
     }
 
     @DeleteMapping(ApiConstant.ID)
+    @Operation(summary = "Delete a player")
     public ResponseEntity<Void> deletePlayer(@PathVariable Long id) {
         playerService.deletePlayer(id);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
This PR adds basic Swagger/OpenAPI documentation to the API:

- Created OpenApiConfig to configure API title, version, and description.
- Added @Tag and @Operation annotations to Player, Club, and Manager controllers.
- Swagger UI is now accessible at swagger-ui/index.html and shows all endpoints with their request/response models.

Closes #7