### PR TITLE
Add global error handling

### DIFF
--- a/src/main/java/com/oscar/football_api/exception/ConflictException.java
+++ b/src/main/java/com/oscar/football_api/exception/ConflictException.java
@@ -1,0 +1,7 @@
+package com.oscar.football_api.exception;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/oscar/football_api/exception/ErrorMessage.java
+++ b/src/main/java/com/oscar/football_api/exception/ErrorMessage.java
@@ -1,0 +1,19 @@
+package com.oscar.football_api.exception;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ErrorMessage {
+
+    private final String error;
+    private final String message;
+    private final Integer code;
+
+    public ErrorMessage(Exception exception, Integer code) {
+        this.error = exception.getClass().getSimpleName();
+        this.message = exception.getMessage();
+        this.code = code;
+    }
+}

--- a/src/main/java/com/oscar/football_api/exception/ForbiddenException.java
+++ b/src/main/java/com/oscar/football_api/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.oscar.football_api.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/oscar/football_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/oscar/football_api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.oscar.football_api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ErrorMessage notFound(Exception exception) {
+        return new ErrorMessage(exception, HttpStatus.NOT_FOUND.value());
+    }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(ConflictException.class)
+    public ErrorMessage conflict(Exception exception) {
+        return new ErrorMessage(exception, HttpStatus.CONFLICT.value());
+    }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(ForbiddenException.class)
+    public ErrorMessage forbidden(Exception exception) {
+        return new ErrorMessage(exception, HttpStatus.FORBIDDEN.value());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            HttpMessageNotReadableException.class
+    })
+    @ResponseBody
+    public ErrorMessage badRequest(Exception exception) {
+        return new ErrorMessage(exception, HttpStatus.BAD_REQUEST.value());
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    @ResponseBody
+    public ErrorMessage exception(Exception exception) {
+        return new ErrorMessage(exception, HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+}

--- a/src/main/java/com/oscar/football_api/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/oscar/football_api/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.oscar.football_api.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
@@ -3,6 +3,7 @@ package com.oscar.football_api.service.impl;
 import com.oscar.football_api.dto.ClubRequestDTO;
 import com.oscar.football_api.dto.response.ClubResponseDTO;
 import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.exception.ResourceNotFoundException;
 import com.oscar.football_api.mapper.ClubMapper;
 import com.oscar.football_api.repository.ClubRepository;
 import com.oscar.football_api.service.ClubService;
@@ -21,12 +22,14 @@ public class ClubServiceImpl implements ClubService {
     private final ClubRepository clubRepository;
     private final ClubMapper clubMapper;
 
+    @Override
     public ClubResponseDTO createClub(ClubRequestDTO requestDTO) {
         Club club = clubMapper.toEntity(requestDTO);
         Club saved = clubRepository.save(club);
         return clubMapper.toDTO(saved);
     }
 
+    @Override
     public List<ClubResponseDTO> getAllClubs() {
         return clubRepository.findAll()
                 .stream()
@@ -34,15 +37,17 @@ public class ClubServiceImpl implements ClubService {
                 .collect(Collectors.toList());
     }
 
+    @Override
     public ClubResponseDTO getClubById(Long id) {
         Club club = clubRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Club not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Club with id " + id + " not found"));
         return clubMapper.toDTO(club);
     }
 
+    @Override
     public ClubResponseDTO updateClub(Long id, ClubRequestDTO requestDTO) {
         Club club = clubRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Club not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Club with id " + id + " not found"));
 
         club.setName(requestDTO.getName());
         club.setEstablishedDate(requestDTO.getEstablishedDate());
@@ -55,9 +60,10 @@ public class ClubServiceImpl implements ClubService {
         return clubMapper.toDTO(updated);
     }
 
+    @Override
     public void deleteClub(Long id) {
         Club club = clubRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Club not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Club with id " + id + " not found"));
         clubRepository.delete(club);
     }
 

--- a/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
@@ -4,6 +4,9 @@ import com.oscar.football_api.dto.ManagerRequestDTO;
 import com.oscar.football_api.dto.response.ManagerResponseDTO;
 import com.oscar.football_api.entity.Club;
 import com.oscar.football_api.entity.Manager;
+import com.oscar.football_api.exception.ConflictException;
+import com.oscar.football_api.exception.ForbiddenException;
+import com.oscar.football_api.exception.ResourceNotFoundException;
 import com.oscar.football_api.mapper.ManagerMapper;
 import com.oscar.football_api.repository.ClubRepository;
 import com.oscar.football_api.repository.ManagerRepository;
@@ -24,12 +27,13 @@ public class ManagerServiceImpl implements ManagerService {
     private final ClubRepository clubRepository;
     private final ManagerMapper managerMapper;
 
+    @Override
     public ManagerResponseDTO createManager(ManagerRequestDTO requestDTO) {
         Club club = clubRepository.findById(requestDTO.getClubId())
-                .orElseThrow(() -> new RuntimeException("Club not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Club with id " + requestDTO.getClubId() + " not found"));
 
         if (club.getManager() != null) {
-            throw new RuntimeException("This club already has a manager assigned.");
+            throw new ConflictException("This club already has a manager assigned.");
         }
 
         Manager manager = managerMapper.toEntity(requestDTO);
@@ -42,6 +46,7 @@ public class ManagerServiceImpl implements ManagerService {
         return managerMapper.toDTO(saved);
     }
 
+    @Override
     public List<ManagerResponseDTO> getAllManagers() {
         return managerRepository.findAll()
                 .stream()
@@ -49,18 +54,20 @@ public class ManagerServiceImpl implements ManagerService {
                 .collect(Collectors.toList());
     }
 
+    @Override
     public ManagerResponseDTO getManagerById(Long id) {
         Manager manager = managerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Manager not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Manager with id " + id + " not found"));
         return managerMapper.toDTO(manager);
     }
 
+    @Override
     public ManagerResponseDTO updateManager(Long id, ManagerRequestDTO requestDTO) {
         Manager manager = managerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Manager not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Manager with id " + id + " not found"));
 
         if (!manager.getClub().getId().equals(requestDTO.getClubId())) {
-            throw new RuntimeException("Cannot change manager's club. Delete and create a new manager instead.");
+            throw new ForbiddenException("Cannot change manager's club. Delete and create a new manager instead");
         }
 
         manager.setName(requestDTO.getName());
@@ -72,9 +79,10 @@ public class ManagerServiceImpl implements ManagerService {
         return managerMapper.toDTO(updated);
     }
 
+    @Override
     public void deleteManager(Long id) {
         Manager manager = managerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Manager not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Manager with id " + id + " not found"));
 
         Club club = manager.getClub();
         if (club != null) {

--- a/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
@@ -6,6 +6,8 @@ import com.oscar.football_api.dto.response.PlayerResponseDTO;
 import com.oscar.football_api.entity.Club;
 import com.oscar.football_api.entity.Manager;
 import com.oscar.football_api.entity.Player;
+import com.oscar.football_api.exception.ConflictException;
+import com.oscar.football_api.exception.ResourceNotFoundException;
 import com.oscar.football_api.mapper.PlayerMapper;
 import com.oscar.football_api.repository.ClubRepository;
 import com.oscar.football_api.repository.PlayerRepository;
@@ -26,13 +28,14 @@ public class PlayerServiceImpl implements PlayerService {
     private final ClubRepository clubRepository;
     private final PlayerMapper playerMapper;
 
+    @Override
     public PlayerResponseDTO createPlayer(PlayerRequestDTO requestDTO) {
         Club club = clubRepository.findById(requestDTO.getClubId())
-                .orElseThrow(() -> new RuntimeException("Club not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Club with id " + requestDTO.getClubId() + " not found"));
 
         playerRepository.findByClubIdAndJerseyNumber(club.getId(), requestDTO.getJerseyNumber())
                 .ifPresent(p -> {
-                    throw new RuntimeException("Jersey number " + requestDTO.getJerseyNumber() + " is already taken in this club");
+                    throw new ConflictException("Jersey number " + requestDTO.getJerseyNumber() + " is already taken in this club");
                 });
 
         Player player = playerMapper.toEntity(requestDTO);
@@ -42,6 +45,7 @@ public class PlayerServiceImpl implements PlayerService {
         return playerMapper.toDTO(saved);
     }
 
+    @Override
     public List<PlayerResponseDTO> getAllPlayers() {
         return playerRepository.findAll()
                 .stream()
@@ -49,23 +53,25 @@ public class PlayerServiceImpl implements PlayerService {
                 .collect(Collectors.toList());
     }
 
+    @Override
     public PlayerResponseDTO getPlayerById(Long id) {
         Player player = playerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Player not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Player with id " + id + " not found"));
         return playerMapper.toDTO(player);
     }
 
+    @Override
     public PlayerResponseDTO updatePlayer(Long id, PlayerRequestDTO requestDTO) {
         Player player = playerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Player not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Player with id " + id + " not found"));
 
         Club club = clubRepository.findById(requestDTO.getClubId())
-                .orElseThrow(() -> new RuntimeException("Club not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Club with id " + requestDTO.getClubId() + " not found"));
 
         playerRepository.findByClubIdAndJerseyNumber(club.getId(), requestDTO.getJerseyNumber())
                 .ifPresent(existing -> {
                     if (!existing.getId().equals(id)) {
-                        throw new RuntimeException("Jersey number already taken in this club");
+                        throw new ConflictException("Jersey number already taken in this club");
                     }
                 });
 
@@ -80,9 +86,10 @@ public class PlayerServiceImpl implements PlayerService {
         return playerMapper.toDTO(playerRepository.save(player));
     }
 
+    @Override
     public void deletePlayer(Long id) {
         Player player = playerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Player not found."));
+                .orElseThrow(() -> new ResourceNotFoundException("Player with id " + id + " not found"));
         playerRepository.delete(player);
     }
 }


### PR DESCRIPTION
This PR adds global exception handling with consistent JSON responses. #12 

**Changes include:**

- @RestControllerAdvice GlobalExceptionHandler for consistent JSON error responses
- Custom exceptions:
    - ResourceNotFoundException -> 404
    - ConflictException -> 409
    - ForbiddenException -> 403
- Services refactored to throw custom exceptions instead of RuntimeException
- ErrorMessage DTO created to standardize error responses
- Handles invalid input (MethodArgumentNotValidException) -> 400
- Catch-all Exception handler -> 500