### PR TITLE
Add pagination sorting and filtering

### DIFF
--- a/src/main/java/com/oscar/football_api/controller/ClubController.java
+++ b/src/main/java/com/oscar/football_api/controller/ClubController.java
@@ -2,12 +2,21 @@ package com.oscar.football_api.controller;
 
 import com.oscar.football_api.dto.ClubRequestDTO;
 import com.oscar.football_api.dto.response.ClubResponseDTO;
+import com.oscar.football_api.dto.response.PageResponseDTO;
+import com.oscar.football_api.dto.search.ClubSearchDTO;
+import com.oscar.football_api.exception.InvalidSortFieldException;
 import com.oscar.football_api.service.ClubService;
 import com.oscar.football_api.utils.ApiConstant;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +31,7 @@ import java.util.List;
 public class ClubController {
 
     private final ClubService clubService;
+    private static final List<String> ALLOWED_SORTS = List.of("name","establishedData","stadiumName","city","league","titlesWon");
 
     @PostMapping
     @Operation(summary = "Create a new club")
@@ -31,8 +41,11 @@ public class ClubController {
 
     @GetMapping
     @Operation(summary = "Get all clubs")
-    public ResponseEntity<List<ClubResponseDTO>> getALlClubs() {
-        return ResponseEntity.ok(clubService.getAllClubs());
+    public ResponseEntity<PageResponseDTO<ClubResponseDTO>> getALlClubs(
+            @ParameterObject @PageableDefault(page = 0, size = 10, sort = "name")Pageable pageable
+            ) {
+        var page =clubService.getAllClubs(pageable);
+        return ResponseEntity.ok(PageResponseDTO.fromPage(page));
     }
 
     @GetMapping(ApiConstant.ID)
@@ -52,5 +65,27 @@ public class ClubController {
     public ResponseEntity<Void> deleteClub(@PathVariable Long id) {
         clubService.deleteClub(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping(ApiConstant.SEARCH)
+    @Operation(summary = "Search clubs with filters, pagination and sorting")
+    public ResponseEntity<PageResponseDTO<ClubResponseDTO>> searchClubs(@ParameterObject ClubSearchDTO criteria) {
+
+        if (!ALLOWED_SORTS.contains(criteria.getSortBy())) {
+            throw new InvalidSortFieldException(criteria.getSortBy());
+        }
+
+        Sort sort = Sort.by(Sort.Direction.fromString(criteria.getSortDir()), criteria.getSortBy());
+        Pageable sortedPageable = PageRequest.of(criteria.getPage(), criteria.getSize(), sort);
+
+        Page<ClubResponseDTO> page = clubService.searchClubs(
+                criteria.getName(),
+                criteria.getCity(),
+                criteria.getStadiumName(),
+                criteria.getLeague(),
+                sortedPageable
+        );
+
+        return ResponseEntity.ok(PageResponseDTO.fromPage(page));
     }
 }

--- a/src/main/java/com/oscar/football_api/controller/ManagerController.java
+++ b/src/main/java/com/oscar/football_api/controller/ManagerController.java
@@ -2,12 +2,21 @@ package com.oscar.football_api.controller;
 
 import com.oscar.football_api.dto.ManagerRequestDTO;
 import com.oscar.football_api.dto.response.ManagerResponseDTO;
+import com.oscar.football_api.dto.response.PageResponseDTO;
+import com.oscar.football_api.dto.search.ManagerSearchDTO;
+import com.oscar.football_api.exception.InvalidSortFieldException;
 import com.oscar.football_api.service.ManagerService;
 import com.oscar.football_api.utils.ApiConstant;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +30,7 @@ import java.util.List;
 public class ManagerController {
 
     private final ManagerService managerService;
+    private static final List<String> ALLOWED_SORTS = List.of("name","nationality","dateOfBirth","titlesWon");
 
     @PostMapping
     @Operation(summary = "Create a new manager")
@@ -30,8 +40,11 @@ public class ManagerController {
 
     @GetMapping
     @Operation(summary = "Get all managers")
-    public ResponseEntity<List<ManagerResponseDTO>> getAllManagers() {
-        return ResponseEntity.ok(managerService.getAllManagers());
+    public ResponseEntity<PageResponseDTO<ManagerResponseDTO>> getAllManagers(
+            @ParameterObject @PageableDefault(page = 0, size = 10, sort = "name")Pageable pageable
+            ) {
+        var page = managerService.getAllManagers(pageable);
+        return ResponseEntity.ok(PageResponseDTO.fromPage(page));
     }
 
     @GetMapping(ApiConstant.ID)
@@ -51,5 +64,26 @@ public class ManagerController {
     public ResponseEntity<Void> deleteManager(@PathVariable Long id) {
         managerService.deleteManager(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping(ApiConstant.SEARCH)
+    @Operation(summary = "Search managers with filters, pagination and sorting")
+    public ResponseEntity<PageResponseDTO<ManagerResponseDTO>> searchManagers(@ParameterObject ManagerSearchDTO criteria) {
+
+        if (!ALLOWED_SORTS.contains(criteria.getSortBy())) {
+            throw new InvalidSortFieldException(criteria.getSortBy());
+        }
+
+        Sort sort = Sort.by(Sort.Direction.fromString(criteria.getSortDir()), criteria.getSortBy());
+        Pageable sortedPageable = PageRequest.of(criteria.getPage(), criteria.getSize(), sort);
+
+        Page<ManagerResponseDTO> page = managerService.searchManagers(
+                criteria.getName(),
+                criteria.getNationality(),
+                criteria.getClubName(),
+                sortedPageable
+        );
+
+        return ResponseEntity.ok(PageResponseDTO.fromPage(page));
     }
 }

--- a/src/main/java/com/oscar/football_api/controller/PlayerController.java
+++ b/src/main/java/com/oscar/football_api/controller/PlayerController.java
@@ -2,12 +2,21 @@ package com.oscar.football_api.controller;
 
 import com.oscar.football_api.dto.PlayerRequestDTO;
 import com.oscar.football_api.dto.response.PlayerResponseDTO;
+import com.oscar.football_api.dto.search.PlayerSearchDTO;
+import com.oscar.football_api.dto.response.PageResponseDTO;
+import com.oscar.football_api.exception.InvalidSortFieldException;
 import com.oscar.football_api.service.PlayerService;
 import com.oscar.football_api.utils.ApiConstant;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +30,7 @@ import java.util.List;
 public class PlayerController {
 
     private final PlayerService playerService;
+    private static final List<String> ALLOWED_SORTS = List.of("name","position","jerseyNumber","dateOfBirth","nationality");
 
     @PostMapping
     @Operation(summary = "Create a new player")
@@ -30,8 +40,11 @@ public class PlayerController {
 
     @GetMapping
     @Operation(summary = "Get all players")
-    public ResponseEntity<List<PlayerResponseDTO>> getAllPlayers() {
-        return ResponseEntity.ok(playerService.getAllPlayers());
+    public ResponseEntity<PageResponseDTO<PlayerResponseDTO>> getAllPlayers(
+            @ParameterObject @PageableDefault(page = 0, size = 10, sort = "name") Pageable pageable
+    ) {
+        var page = playerService.getAllPlayers(pageable);
+        return ResponseEntity.ok(PageResponseDTO.fromPage(page));
     }
 
     @GetMapping(ApiConstant.ID)
@@ -51,5 +64,26 @@ public class PlayerController {
     public ResponseEntity<Void> deletePlayer(@PathVariable Long id) {
         playerService.deletePlayer(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping(ApiConstant.SEARCH)
+    @Operation(summary = "Search players with filters, pagination and sorting")
+    public ResponseEntity<PageResponseDTO<PlayerResponseDTO>> searchPlayers(@ParameterObject PlayerSearchDTO criteria) {
+
+        if (!ALLOWED_SORTS.contains(criteria.getSortBy())) {
+            throw new InvalidSortFieldException(criteria.getSortBy());
+        }
+
+        Sort sort = Sort.by(Sort.Direction.fromString(criteria.getSortDir()), criteria.getSortBy());
+        Pageable sortedPageable = PageRequest.of(criteria.getPage(), criteria.getSize(), sort);
+
+        Page<PlayerResponseDTO> page = playerService.searchPlayers(
+                criteria.getPosition(),
+                criteria.getName(),
+                criteria.getNationality(),
+                sortedPageable
+        );
+
+        return ResponseEntity.ok(PageResponseDTO.fromPage(page));
     }
 }

--- a/src/main/java/com/oscar/football_api/dto/response/PageResponseDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/response/PageResponseDTO.java
@@ -1,0 +1,30 @@
+package com.oscar.football_api.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PageResponseDTO<T> {
+
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+
+    public static <T> PageResponseDTO<T> fromPage(Page<T> page) {
+        return new PageResponseDTO<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
+}

--- a/src/main/java/com/oscar/football_api/dto/search/ClubSearchDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/search/ClubSearchDTO.java
@@ -1,0 +1,21 @@
+package com.oscar.football_api.dto.search;
+
+import com.oscar.football_api.entity.enums.League;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClubSearchDTO {
+
+    private String name;
+    private String city;
+    private String stadiumName;
+    private League league;
+    private String sortBy = "name";
+    private String sortDir = "asc";
+    private int page = 0;
+    private int size = 10;
+}

--- a/src/main/java/com/oscar/football_api/dto/search/ManagerSearchDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/search/ManagerSearchDTO.java
@@ -1,0 +1,19 @@
+package com.oscar.football_api.dto.search;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ManagerSearchDTO {
+
+    private String name;
+    private String nationality;
+    private String clubName;
+    private String sortBy = "name";
+    private String sortDir = "asc";
+    private int page = 0;
+    private int size = 10;
+}

--- a/src/main/java/com/oscar/football_api/dto/search/PlayerSearchDTO.java
+++ b/src/main/java/com/oscar/football_api/dto/search/PlayerSearchDTO.java
@@ -1,0 +1,20 @@
+package com.oscar.football_api.dto.search;
+
+import com.oscar.football_api.entity.enums.Position;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlayerSearchDTO {
+
+    private Position position;
+    private String name;
+    private String nationality;
+    private String sortBy = "name";
+    private String sortDir = "asc";
+    private int page = 0;
+    private int size = 10;
+}

--- a/src/main/java/com/oscar/football_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/oscar/football_api/exception/GlobalExceptionHandler.java
@@ -32,7 +32,8 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler({
             MethodArgumentNotValidException.class,
-            HttpMessageNotReadableException.class
+            HttpMessageNotReadableException.class,
+            InvalidSortFieldException.class
     })
     @ResponseBody
     public ErrorMessage badRequest(Exception exception) {

--- a/src/main/java/com/oscar/football_api/exception/InvalidSortFieldException.java
+++ b/src/main/java/com/oscar/football_api/exception/InvalidSortFieldException.java
@@ -1,0 +1,7 @@
+package com.oscar.football_api.exception;
+
+public class InvalidSortFieldException extends RuntimeException {
+    public InvalidSortFieldException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/oscar/football_api/repository/ClubRepository.java
+++ b/src/main/java/com/oscar/football_api/repository/ClubRepository.java
@@ -2,8 +2,9 @@ package com.oscar.football_api.repository;
 
 import com.oscar.football_api.entity.Club;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ClubRepository extends JpaRepository<Club, Long> {
+public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificationExecutor<Club> {
 }

--- a/src/main/java/com/oscar/football_api/repository/ManagerRepository.java
+++ b/src/main/java/com/oscar/football_api/repository/ManagerRepository.java
@@ -2,8 +2,9 @@ package com.oscar.football_api.repository;
 
 import com.oscar.football_api.entity.Manager;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ManagerRepository extends JpaRepository<Manager, Long> {
+public interface ManagerRepository extends JpaRepository<Manager, Long>, JpaSpecificationExecutor<Manager> {
 }

--- a/src/main/java/com/oscar/football_api/repository/PlayerRepository.java
+++ b/src/main/java/com/oscar/football_api/repository/PlayerRepository.java
@@ -2,12 +2,13 @@ package com.oscar.football_api.repository;
 
 import com.oscar.football_api.entity.Player;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface PlayerRepository extends JpaRepository<Player, Long> {
+public interface PlayerRepository extends JpaRepository<Player, Long>, JpaSpecificationExecutor<Player> {
 
     Optional<Player> findByClubIdAndJerseyNumber(Long clubId, int jerseyNumber);
 }

--- a/src/main/java/com/oscar/football_api/repository/specifications/ClubSpecifications.java
+++ b/src/main/java/com/oscar/football_api/repository/specifications/ClubSpecifications.java
@@ -1,0 +1,28 @@
+package com.oscar.football_api.repository.specifications;
+
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.enums.League;
+import org.springframework.data.jpa.domain.Specification;
+
+public class ClubSpecifications {
+
+    public static Specification<Club> hasName(String name) {
+        return (root, query, cb) ->
+                name == null ? null : cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%");
+    }
+
+    public static Specification<Club> hasCity(String city) {
+        return (root, query, cb) ->
+                city == null ? null : cb.like(cb.lower(root.get("city")), "%" + city.toLowerCase() + "%");
+    }
+
+    public static Specification<Club> hasStadiumName(String stadiumName) {
+        return (root, query, cb) ->
+                stadiumName == null ? null : cb.like(cb.lower(root.get("stadiumName")), "%" + stadiumName.toLowerCase() + "%");
+    }
+
+    public static Specification<Club> hasLeague(League league) {
+        return (root, query, cb) ->
+                league == null ? null : cb.equal(root.get("league"), league);
+    }
+}

--- a/src/main/java/com/oscar/football_api/repository/specifications/ManagerSpecifications.java
+++ b/src/main/java/com/oscar/football_api/repository/specifications/ManagerSpecifications.java
@@ -1,0 +1,22 @@
+package com.oscar.football_api.repository.specifications;
+
+import com.oscar.football_api.entity.Manager;
+import org.springframework.data.jpa.domain.Specification;
+
+public class ManagerSpecifications {
+
+    public static Specification<Manager> hasName(String name) {
+        return (root, query, cb) ->
+                name == null ? null : cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%");
+    }
+
+    public static Specification<Manager> hasNationality(String nationality) {
+        return (root, query, cb) ->
+                nationality == null ? null : cb.equal(root.get("nationality"), nationality);
+    }
+
+    public static Specification<Manager> hasClubName(String clubName) {
+        return (root, query, cb) ->
+                clubName == null ? null : cb.equal(root.join("club").get("name"), clubName);
+    }
+}

--- a/src/main/java/com/oscar/football_api/repository/specifications/PlayerSpecifications.java
+++ b/src/main/java/com/oscar/football_api/repository/specifications/PlayerSpecifications.java
@@ -1,0 +1,23 @@
+package com.oscar.football_api.repository.specifications;
+
+import com.oscar.football_api.entity.Player;
+import com.oscar.football_api.entity.enums.Position;
+import org.springframework.data.jpa.domain.Specification;
+
+public class PlayerSpecifications {
+
+    public static Specification<Player> hasPosition(Position position) {
+        return (root, query, cb) ->
+                position == null ? null : cb.equal(root.get("position"), position);
+    }
+
+    public static Specification<Player> hasName(String name) {
+        return (root, query, cb) ->
+                name == null ? null : cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%");
+    }
+
+    public static Specification<Player> hasNationality(String nationality) {
+        return (root, query, cb) ->
+                nationality == null ? null : cb.equal(root.get("nationality"), nationality);
+    }
+}

--- a/src/main/java/com/oscar/football_api/service/ClubService.java
+++ b/src/main/java/com/oscar/football_api/service/ClubService.java
@@ -2,14 +2,16 @@ package com.oscar.football_api.service;
 
 import com.oscar.football_api.dto.ClubRequestDTO;
 import com.oscar.football_api.dto.response.ClubResponseDTO;
-
-import java.util.List;
+import com.oscar.football_api.entity.enums.League;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ClubService {
 
     ClubResponseDTO createClub(ClubRequestDTO requestDTO);
-    List<ClubResponseDTO> getAllClubs();
+    Page<ClubResponseDTO> getAllClubs(Pageable pageable);
     ClubResponseDTO getClubById(Long id);
     ClubResponseDTO updateClub(Long id, ClubRequestDTO requestDTO);
     void deleteClub(Long id);
+    Page<ClubResponseDTO> searchClubs(String name, String city, String stadiumName, League league, Pageable pageable);
 }

--- a/src/main/java/com/oscar/football_api/service/ManagerService.java
+++ b/src/main/java/com/oscar/football_api/service/ManagerService.java
@@ -2,14 +2,15 @@ package com.oscar.football_api.service;
 
 import com.oscar.football_api.dto.ManagerRequestDTO;
 import com.oscar.football_api.dto.response.ManagerResponseDTO;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ManagerService {
 
     ManagerResponseDTO createManager(ManagerRequestDTO requestDTO);
-    List<ManagerResponseDTO> getAllManagers();
+    Page<ManagerResponseDTO> getAllManagers(Pageable pageable);
     ManagerResponseDTO getManagerById(Long id);
     ManagerResponseDTO updateManager(Long id, ManagerRequestDTO requestDTO);
     void deleteManager(Long id);
+    Page<ManagerResponseDTO> searchManagers(String name, String nationality, String clubName, Pageable pageable);
 }

--- a/src/main/java/com/oscar/football_api/service/PlayerService.java
+++ b/src/main/java/com/oscar/football_api/service/PlayerService.java
@@ -2,14 +2,18 @@ package com.oscar.football_api.service;
 
 import com.oscar.football_api.dto.PlayerRequestDTO;
 import com.oscar.football_api.dto.response.PlayerResponseDTO;
+import com.oscar.football_api.entity.enums.Position;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface PlayerService {
 
     PlayerResponseDTO createPlayer(PlayerRequestDTO requestDTO);
-    List<PlayerResponseDTO> getAllPlayers();
+    Page<PlayerResponseDTO> getAllPlayers(Pageable pageable);
     PlayerResponseDTO getPlayerById(Long id);
     PlayerResponseDTO updatePlayer(Long id, PlayerRequestDTO requestDTO);
     void deletePlayer(Long id);
+    Page<PlayerResponseDTO> searchPlayers(Position position, String name, String nationality, Pageable pageable);
 }

--- a/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ClubServiceImpl.java
@@ -3,16 +3,18 @@ package com.oscar.football_api.service.impl;
 import com.oscar.football_api.dto.ClubRequestDTO;
 import com.oscar.football_api.dto.response.ClubResponseDTO;
 import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.enums.League;
 import com.oscar.football_api.exception.ResourceNotFoundException;
 import com.oscar.football_api.mapper.ClubMapper;
 import com.oscar.football_api.repository.ClubRepository;
+import com.oscar.football_api.repository.specifications.ClubSpecifications;
 import com.oscar.football_api.service.ClubService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,11 +32,9 @@ public class ClubServiceImpl implements ClubService {
     }
 
     @Override
-    public List<ClubResponseDTO> getAllClubs() {
-        return clubRepository.findAll()
-                .stream()
-                .map(clubMapper::toDTO)
-                .collect(Collectors.toList());
+    public Page<ClubResponseDTO> getAllClubs(Pageable pageable) {
+        return clubRepository.findAll(pageable)
+                .map(clubMapper::toDTO);
     }
 
     @Override
@@ -67,4 +67,14 @@ public class ClubServiceImpl implements ClubService {
         clubRepository.delete(club);
     }
 
+    @Override
+    public Page<ClubResponseDTO> searchClubs(String name, String city, String stadiumName, League league, Pageable pageable) {
+        Specification<Club> spec = Specification
+                .where(ClubSpecifications.hasName(name))
+                .and(ClubSpecifications.hasCity(city))
+                .and(ClubSpecifications.hasStadiumName(stadiumName))
+                .and(ClubSpecifications.hasLeague(league));
+
+        return clubRepository.findAll(spec, pageable).map(clubMapper::toDTO);
+    }
 }

--- a/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/ManagerServiceImpl.java
@@ -4,19 +4,22 @@ import com.oscar.football_api.dto.ManagerRequestDTO;
 import com.oscar.football_api.dto.response.ManagerResponseDTO;
 import com.oscar.football_api.entity.Club;
 import com.oscar.football_api.entity.Manager;
+import com.oscar.football_api.entity.Player;
 import com.oscar.football_api.exception.ConflictException;
 import com.oscar.football_api.exception.ForbiddenException;
 import com.oscar.football_api.exception.ResourceNotFoundException;
 import com.oscar.football_api.mapper.ManagerMapper;
 import com.oscar.football_api.repository.ClubRepository;
 import com.oscar.football_api.repository.ManagerRepository;
+import com.oscar.football_api.repository.specifications.ManagerSpecifications;
+import com.oscar.football_api.repository.specifications.PlayerSpecifications;
 import com.oscar.football_api.service.ManagerService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -47,11 +50,9 @@ public class ManagerServiceImpl implements ManagerService {
     }
 
     @Override
-    public List<ManagerResponseDTO> getAllManagers() {
-        return managerRepository.findAll()
-                .stream()
-                .map(managerMapper::toDTO)
-                .collect(Collectors.toList());
+    public Page<ManagerResponseDTO> getAllManagers(Pageable pageable) {
+        return managerRepository.findAll(pageable)
+                .map(managerMapper::toDTO);
     }
 
     @Override
@@ -92,5 +93,15 @@ public class ManagerServiceImpl implements ManagerService {
         }
 
         managerRepository.delete(manager);
+    }
+
+    @Override
+    public Page<ManagerResponseDTO> searchManagers(String name, String nationality, String clubName, Pageable pageable) {
+        Specification<Manager> spec = Specification
+                .where(ManagerSpecifications.hasName(name))
+                .and(ManagerSpecifications.hasNationality(nationality))
+                .and(ManagerSpecifications.hasClubName(clubName));
+
+        return managerRepository.findAll(spec, pageable).map(managerMapper::toDTO);
     }
 }

--- a/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
@@ -6,14 +6,19 @@ import com.oscar.football_api.dto.response.PlayerResponseDTO;
 import com.oscar.football_api.entity.Club;
 import com.oscar.football_api.entity.Manager;
 import com.oscar.football_api.entity.Player;
+import com.oscar.football_api.entity.enums.Position;
 import com.oscar.football_api.exception.ConflictException;
 import com.oscar.football_api.exception.ResourceNotFoundException;
 import com.oscar.football_api.mapper.PlayerMapper;
 import com.oscar.football_api.repository.ClubRepository;
 import com.oscar.football_api.repository.PlayerRepository;
+import com.oscar.football_api.repository.specifications.PlayerSpecifications;
 import com.oscar.football_api.service.PlayerService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -46,11 +51,9 @@ public class PlayerServiceImpl implements PlayerService {
     }
 
     @Override
-    public List<PlayerResponseDTO> getAllPlayers() {
-        return playerRepository.findAll()
-                .stream()
-                .map(playerMapper::toDTO)
-                .collect(Collectors.toList());
+    public Page<PlayerResponseDTO> getAllPlayers(Pageable pageable) {
+        return playerRepository.findAll(pageable)
+                .map(playerMapper::toDTO);
     }
 
     @Override
@@ -91,5 +94,14 @@ public class PlayerServiceImpl implements PlayerService {
         Player player = playerRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Player with id " + id + " not found"));
         playerRepository.delete(player);
+    }
+
+    public Page<PlayerResponseDTO> searchPlayers(Position position, String name, String nationality, Pageable pageable) {
+        Specification<Player> spec = Specification
+                .where(PlayerSpecifications.hasPosition(position))
+                .and(PlayerSpecifications.hasName(name))
+                .and(PlayerSpecifications.hasNationality(nationality));
+
+        return playerRepository.findAll(spec, pageable).map(playerMapper::toDTO);
     }
 }

--- a/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/com/oscar/football_api/service/impl/PlayerServiceImpl.java
@@ -1,10 +1,8 @@
 package com.oscar.football_api.service.impl;
 
 import com.oscar.football_api.dto.PlayerRequestDTO;
-import com.oscar.football_api.dto.response.ManagerResponseDTO;
 import com.oscar.football_api.dto.response.PlayerResponseDTO;
 import com.oscar.football_api.entity.Club;
-import com.oscar.football_api.entity.Manager;
 import com.oscar.football_api.entity.Player;
 import com.oscar.football_api.entity.enums.Position;
 import com.oscar.football_api.exception.ConflictException;
@@ -20,9 +18,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -96,6 +91,7 @@ public class PlayerServiceImpl implements PlayerService {
         playerRepository.delete(player);
     }
 
+    @Override
     public Page<PlayerResponseDTO> searchPlayers(Position position, String name, String nationality, Pageable pageable) {
         Specification<Player> spec = Specification
                 .where(PlayerSpecifications.hasPosition(position))

--- a/src/main/java/com/oscar/football_api/utils/ApiConstant.java
+++ b/src/main/java/com/oscar/football_api/utils/ApiConstant.java
@@ -11,5 +11,6 @@ public class ApiConstant {
     public static final String PLAYERS = "/players";
     public static final String MANAGERS = "/managers";
     public static final String ID = "/{id}";
+    public static final String SEARCH = "/search";
 
 }


### PR DESCRIPTION
This PR implements the following features across the API:

**Implemented Features:**
- Pagination for GET endpoints (Players, Managers, Clubs)
- Sorting for GET endpoints with configurable sortBy and sortDir
- Filtering/searching with optional query parameters:
    - Players: position, name, nationality
    - Managers: name, nationality, clubName
    - Clubs: name, city, stadiumName, league
    - Search endpoints support multiple optional filters
- All paginated responses return a consistent PageResponseDTO
- Validation of sortBy fields to prevent invalid sorting
- Error handling for InvalidSortFieldException through GlobalExceptionHandler

Closes #18 
