### PR TITLE
Add unit and integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Environment variables -->
         <dependency>
             <groupId>me.paulschwarz</groupId>

--- a/src/test/java/com/oscar/football_api/FootballApiApplicationTests.java
+++ b/src/test/java/com/oscar/football_api/FootballApiApplicationTests.java
@@ -2,8 +2,10 @@ package com.oscar.football_api;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class FootballApiApplicationTests {
 
 	@Test

--- a/src/test/java/com/oscar/football_api/controller/ClubControllerTest.java
+++ b/src/test/java/com/oscar/football_api/controller/ClubControllerTest.java
@@ -1,0 +1,87 @@
+package com.oscar.football_api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oscar.football_api.dto.ClubRequestDTO;
+import com.oscar.football_api.dto.response.ClubResponseDTO;
+import com.oscar.football_api.entity.enums.League;
+import com.oscar.football_api.mapper.ClubMapper;
+import com.oscar.football_api.service.ClubService;
+import com.oscar.football_api.utils.ApiConstant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@WebMvcTest(ClubController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ClubControllerTest {
+
+    @MockBean private ClubService clubService;
+    @MockBean private ClubMapper clubMapper;
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Test
+    void givenValidClubRequest_whenCreateClub_thenReturn201() throws Exception {
+        ClubRequestDTO requestDTO = ClubRequestDTO.builder()
+                .name("FC Barcelona")
+                .establishedDate(LocalDate.of(1899, 11, 29))
+                .stadiumName("Camp Nou")
+                .city("Barcelona")
+                .league(League.LA_LIGA)
+                .titlesWon(75)
+                .build();
+
+        ClubResponseDTO responseDTO = new ClubResponseDTO();
+        when(clubService.createClub(requestDTO)).thenReturn(responseDTO);
+
+        MockHttpServletResponse response = mockMvc.perform(
+                post(ApiConstant.API + ApiConstant.V1 + ApiConstant.CLUBS)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(requestDTO))
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus(), is(HttpStatus.CREATED.value()));
+    }
+
+    @Test
+    void givenClubRequestWithEmptyName_whenCreateClub_thenReturn400() throws Exception {
+        ClubRequestDTO requestDTO = ClubRequestDTO.builder()
+                .name("")
+                .establishedDate(LocalDate.of(1899, 11, 29))
+                .stadiumName("Camp Nou")
+                .city("Barcelona")
+                .league(League.LA_LIGA)
+                .titlesWon(75)
+                .build();
+
+        MockHttpServletResponse response = mockMvc.perform(
+                post(ApiConstant.API + ApiConstant.V1 + ApiConstant.CLUBS)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(requestDTO))
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus(), is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void givenId_whenDeleteClub_thenReturn204() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(
+                delete(ApiConstant.API + ApiConstant.V1 + ApiConstant.CLUBS + "/1")
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus(), is(HttpStatus.NO_CONTENT.value()));
+    }
+}

--- a/src/test/java/com/oscar/football_api/controller/ManagerControllerTest.java
+++ b/src/test/java/com/oscar/football_api/controller/ManagerControllerTest.java
@@ -1,0 +1,84 @@
+package com.oscar.football_api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oscar.football_api.dto.ManagerRequestDTO;
+import com.oscar.football_api.dto.response.ManagerResponseDTO;
+import com.oscar.football_api.mapper.ManagerMapper;
+import com.oscar.football_api.service.ManagerService;
+import com.oscar.football_api.utils.ApiConstant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@WebMvcTest(ManagerController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ManagerControllerTest {
+
+    @MockBean private ManagerService managerService;
+    @MockBean private ManagerMapper managerMapper;
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Test
+    void givenValidManagerRequest_whenCreateManager_thenReturn201() throws Exception {
+        ManagerRequestDTO requestDTO = ManagerRequestDTO.builder()
+                .name("Pep Guardiola")
+                .nationality("Spanish")
+                .dateOfBirth(LocalDate.of(1971, 1, 18))
+                .titlesWon(30)
+                .clubId(1L)
+                .build();
+
+        ManagerResponseDTO responseDTO = new ManagerResponseDTO();
+        when(managerService.createManager(requestDTO)).thenReturn(responseDTO);
+
+        MockHttpServletResponse response = mockMvc.perform(
+                post(ApiConstant.API + ApiConstant.V1 + ApiConstant.MANAGERS)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(requestDTO))
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus(), is(HttpStatus.CREATED.value()));
+    }
+
+    @Test
+    void givenManagerRequestWithEmptyName_whenCreateManager_thenReturn400() throws Exception {
+        ManagerRequestDTO requestDTO = ManagerRequestDTO.builder()
+                .name("")
+                .nationality("Spanish")
+                .dateOfBirth(LocalDate.of(1971, 1, 18))
+                .titlesWon(30)
+                .clubId(1L)
+                .build();
+
+        MockHttpServletResponse response = mockMvc.perform(
+                post(ApiConstant.API + ApiConstant.V1 + ApiConstant.MANAGERS)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(requestDTO))
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus(), is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void givenId_whenDeleteManager_thenReturn204() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(
+                delete(ApiConstant.API + ApiConstant.V1 + ApiConstant.MANAGERS + "/1")
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus(), is(HttpStatus.NO_CONTENT.value()));
+    }
+}

--- a/src/test/java/com/oscar/football_api/controller/PlayerControllerTest.java
+++ b/src/test/java/com/oscar/football_api/controller/PlayerControllerTest.java
@@ -1,0 +1,87 @@
+package com.oscar.football_api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oscar.football_api.dto.PlayerRequestDTO;
+import com.oscar.football_api.dto.response.PlayerResponseDTO;
+import com.oscar.football_api.entity.enums.Position;
+import com.oscar.football_api.mapper.PlayerMapper;
+import com.oscar.football_api.service.PlayerService;
+import com.oscar.football_api.utils.ApiConstant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@WebMvcTest(PlayerController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlayerControllerTest {
+
+    @MockBean private PlayerService playerService;
+    @MockBean private PlayerMapper playerMapper;
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Test
+    void givenValidPlayerRequest_whenCreatePlayer_thenReturn201() throws Exception {
+        PlayerRequestDTO requestDTO = PlayerRequestDTO.builder()
+                .name("Lionel Messi")
+                .position(Position.FORWARD)
+                .jerseyNumber(10)
+                .dateOfBirth(LocalDate.of(1987, 6, 24))
+                .nationality("Argentinian")
+                .clubId(1L)
+                .build();
+
+        PlayerResponseDTO responseDTO = new PlayerResponseDTO();
+        when(playerService.createPlayer(requestDTO)).thenReturn(responseDTO);
+
+        MockHttpServletResponse response = mockMvc.perform(
+                post(ApiConstant.API + ApiConstant.V1 + ApiConstant.PLAYERS)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(requestDTO))
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus(), is(HttpStatus.CREATED.value()));
+    }
+
+    @Test
+    void givenPlayerRequestWithEmptyName_whenCreatePlayer_thenReturn400() throws Exception {
+        PlayerRequestDTO requestDTO = PlayerRequestDTO.builder()
+                .name("")
+                .position(Position.FORWARD)
+                .jerseyNumber(10)
+                .dateOfBirth(LocalDate.of(1987, 6, 24))
+                .nationality("Argentinian")
+                .clubId(1L)
+                .build();
+
+        MockHttpServletResponse response = mockMvc.perform(
+                post(ApiConstant.API + ApiConstant.V1 + ApiConstant.PLAYERS)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(requestDTO))
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus(), is(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void givenId_whenDeletePlayer_thenReturn204() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(
+                delete(ApiConstant.API + ApiConstant.V1 + ApiConstant.PLAYERS + "/1")
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus(), is(HttpStatus.NO_CONTENT.value()));
+    }
+}

--- a/src/test/java/com/oscar/football_api/mapper/ClubMapperTest.java
+++ b/src/test/java/com/oscar/football_api/mapper/ClubMapperTest.java
@@ -1,0 +1,73 @@
+package com.oscar.football_api.mapper;
+
+import com.oscar.football_api.dto.ClubRequestDTO;
+import com.oscar.football_api.dto.response.ClubResponseDTO;
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.Manager;
+import com.oscar.football_api.entity.Player;
+import com.oscar.football_api.entity.enums.League;
+import com.oscar.football_api.entity.enums.Position;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ClubMapperTest {
+
+    @Autowired
+    private ClubMapper mapper;
+
+    @Test
+    void testToEntity() {
+        ClubRequestDTO dto = new ClubRequestDTO();
+        dto.setName("FC Barcelona");
+        dto.setCity("Barcelona");
+        dto.setStadiumName("Camp Nou");
+        dto.setLeague(League.LA_LIGA);
+        dto.setTitlesWon(27);
+        dto.setEstablishedDate(LocalDate.of(1899, 11, 29));
+
+        Club club = mapper.toEntity(dto);
+
+        assertThat(club).isNotNull();
+        assertThat(club.getName()).isEqualTo("FC Barcelona");
+        assertThat(club.getLeague()).isEqualTo(League.LA_LIGA);
+    }
+
+    @Test
+    void testToDTO() {
+        Club club = new Club();
+        club.setName("FC Barcelona");
+        club.setCity("Barcelona");
+        club.setStadiumName("Camp Nou");
+        club.setLeague(League.LA_LIGA);
+        club.setTitlesWon(27);
+        club.setEstablishedDate(LocalDate.of(1899, 11, 29));
+
+        club.setPlayers(new ArrayList<>());
+        Player player = new Player();
+        player.setName("Messi");
+        player.setPosition(Position.FORWARD);
+        club.getPlayers().add(player);
+
+        Manager manager = new Manager();
+        manager.setName("Xavi");
+        club.setManager(manager);
+
+        ClubResponseDTO dto = mapper.toDTO(club);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.getName()).isEqualTo("FC Barcelona");
+        assertThat(dto.getPlayers()).hasSize(1);
+        assertThat(dto.getPlayers().get(0).getName()).isEqualTo("Messi");
+        assertThat(dto.getManager()).isNotNull();
+        assertThat(dto.getManager().getName()).isEqualTo("Xavi");
+    }
+}

--- a/src/test/java/com/oscar/football_api/mapper/ManagerMapperTest.java
+++ b/src/test/java/com/oscar/football_api/mapper/ManagerMapperTest.java
@@ -1,0 +1,55 @@
+package com.oscar.football_api.mapper;
+
+import com.oscar.football_api.dto.ManagerRequestDTO;
+import com.oscar.football_api.dto.response.ManagerResponseDTO;
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.Manager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ManagerMapperTest {
+
+    @Autowired
+    private ManagerMapper mapper;
+
+    @Test
+    void testToEntity() {
+        ManagerRequestDTO dto = new ManagerRequestDTO();
+        dto.setName("Xavi");
+        dto.setNationality("Spanish");
+        dto.setDateOfBirth(LocalDate.of(1980, 1, 25));
+        dto.setTitlesWon(10);
+        dto.setClubId(1L);
+
+        Manager manager = mapper.toEntity(dto);
+
+        assertThat(manager).isNotNull();
+        assertThat(manager.getName()).isEqualTo("Xavi");
+        assertThat(manager.getClub().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void testToDTO() {
+        Club club = new Club();
+        club.setId(1L);
+
+        Manager manager = new Manager();
+        manager.setName("Xavi");
+        manager.setNationality("Spanish");
+        manager.setClub(club);
+
+        ManagerResponseDTO dto = mapper.toDTO(manager);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.getName()).isEqualTo("Xavi");
+        assertThat(dto.getClubId()).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/oscar/football_api/mapper/PlayerMapperTest.java
+++ b/src/test/java/com/oscar/football_api/mapper/PlayerMapperTest.java
@@ -1,0 +1,62 @@
+package com.oscar.football_api.mapper;
+
+import com.oscar.football_api.dto.PlayerRequestDTO;
+import com.oscar.football_api.dto.response.PlayerResponseDTO;
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.Player;
+import com.oscar.football_api.entity.enums.Position;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PlayerMapperTest {
+
+    @Autowired
+    private PlayerMapper mapper;
+
+    @Test
+    void testToEntity() {
+        PlayerRequestDTO dto = new PlayerRequestDTO();
+        dto.setName("Messi");
+        dto.setPosition(Position.FORWARD);
+        dto.setJerseyNumber(10);
+        dto.setDateOfBirth(LocalDate.of(1987, 6, 24));
+        dto.setNationality("Argentinian");
+        dto.setClubId(1L);
+
+        Player player = mapper.toEntity(dto);
+
+        assertThat(player).isNotNull();
+        assertThat(player.getName()).isEqualTo("Messi");
+        assertThat(player.getPosition()).isEqualTo(Position.FORWARD);
+        assertThat(player.getJerseyNumber()).isEqualTo(10);
+        assertThat(player.getClub().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void testToDTO() {
+        Club club = new Club();
+        club.setId(1L);
+
+        Player player = new Player();
+        player.setName("Messi");
+        player.setPosition(Position.FORWARD);
+        player.setJerseyNumber(10);
+        player.setNationality("Argentinian");
+        player.setClub(club);
+
+        PlayerResponseDTO dto = mapper.toDTO(player);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.getName()).isEqualTo("Messi");
+        assertThat(dto.getPosition()).isEqualTo(Position.FORWARD);
+        assertThat(dto.getClubId()).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/oscar/football_api/repository/ClubRepositoryTest.java
+++ b/src/test/java/com/oscar/football_api/repository/ClubRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.oscar.football_api.repository;
+
+import com.oscar.football_api.entity.enums.League;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ClubRepositoryTest {
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Test
+    void testSearchByNameCityStadiumLeague() {
+        var pageable = PageRequest.of(0, 10);
+
+        var result = clubRepository.search("Barcelona", "Barcelona", "Camp Nou", League.LA_LIGA, pageable);
+        assertThat(result).isNotEmpty();
+        assertThat(result.getContent().get(0).getName()).isEqualTo("FC Barcelona");
+
+        var allClubs = clubRepository.search(null, null, null, null, pageable);
+        assertThat(allClubs.getTotalElements()).isGreaterThan(0);
+    }
+}

--- a/src/test/java/com/oscar/football_api/repository/ManagerRepositoryTest.java
+++ b/src/test/java/com/oscar/football_api/repository/ManagerRepositoryTest.java
@@ -1,0 +1,29 @@
+package com.oscar.football_api.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ManagerRepositoryTest {
+
+    @Autowired
+    private ManagerRepository managerRepository;
+
+    @Test
+    void testSearchByNameNationalityClubName() {
+        var pageable = PageRequest.of(0, 10);
+
+        var result = managerRepository.search("Hansi Flick", "German", "Barcelona", pageable);
+        assertThat(result).isNotEmpty();
+        assertThat(result.getContent().get(0).getName()).isEqualTo("Hansi Flick");
+
+        var allManagers = managerRepository.search(null, null, null, pageable);
+        assertThat(allManagers.getTotalElements()).isGreaterThan(0);
+    }
+}

--- a/src/test/java/com/oscar/football_api/repository/PlayerRepositoryTest.java
+++ b/src/test/java/com/oscar/football_api/repository/PlayerRepositoryTest.java
@@ -1,0 +1,40 @@
+package com.oscar.football_api.repository;
+
+import com.oscar.football_api.entity.Player;
+import com.oscar.football_api.entity.enums.Position;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class PlayerRepositoryTest {
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @Test
+    void testFindByClubIdAndJerseyNumber() {
+        Optional<Player> playerOpt = playerRepository.findByClubIdAndJerseyNumber(1L, 1);
+        assertThat(playerOpt).isPresent();
+        assertThat(playerOpt.get().getName()).isEqualTo("Marc-André ter Stegen");
+    }
+
+    @Test
+    void testSearchByPositionNameNationality() {
+        var pageable = PageRequest.of(0, 10);
+
+        var result = playerRepository.search(Position.MIDFIELDER, "Pedri", "Spanish", pageable);
+        assertThat(result).isNotEmpty();
+        assertThat(result.getContent().get(0).getName()).isEqualTo("Pedri");
+
+        var allPlayers = playerRepository.search(null, null, null, pageable);
+        assertThat(allPlayers.getTotalElements()).isGreaterThan(0);
+    }
+}

--- a/src/test/java/com/oscar/football_api/service/ClubServiceImplTest.java
+++ b/src/test/java/com/oscar/football_api/service/ClubServiceImplTest.java
@@ -1,0 +1,96 @@
+package com.oscar.football_api.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import com.oscar.football_api.dto.ClubRequestDTO;
+import com.oscar.football_api.dto.response.ClubResponseDTO;
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.exception.ResourceNotFoundException;
+import com.oscar.football_api.mapper.ClubMapper;
+import com.oscar.football_api.repository.ClubRepository;
+import java.util.Optional;
+
+import com.oscar.football_api.service.impl.ClubServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Collections;
+
+@ExtendWith(MockitoExtension.class)
+class ClubServiceImplTest {
+
+    @InjectMocks private ClubServiceImpl clubService;
+
+    @Mock private ClubRepository clubRepository;
+    @Mock private ClubMapper clubMapper;
+
+    @Test
+    void givenClubRequestDTOWhenCreateClubThenReturnClubResponseDTO() {
+        ClubRequestDTO requestDTO = new ClubRequestDTO();
+        requestDTO.setName("Real Madrid");
+
+        Club club = mock(Club.class);
+        Club saved = mock(Club.class);
+        ClubResponseDTO dto = mock(ClubResponseDTO.class);
+
+        when(clubMapper.toEntity(requestDTO)).thenReturn(club);
+        when(clubRepository.save(club)).thenReturn(saved);
+        when(clubMapper.toDTO(saved)).thenReturn(dto);
+
+        ClubResponseDTO result = clubService.createClub(requestDTO);
+
+        verify(clubRepository, times(1)).save(club);
+        verify(clubMapper, times(1)).toEntity(requestDTO);
+        verify(clubMapper, times(1)).toDTO(saved);
+
+        assertThat(result, is(dto));
+    }
+
+    @Test
+    void givenExistingClubIdWhenGetClubByIdThenReturnDTO() {
+        Long id = 1L;
+        Club club = mock(Club.class);
+        ClubResponseDTO dto = mock(ClubResponseDTO.class);
+
+        when(clubRepository.findById(id)).thenReturn(Optional.of(club));
+        when(clubMapper.toDTO(club)).thenReturn(dto);
+
+        ClubResponseDTO result = clubService.getClubById(id);
+
+        verify(clubRepository, times(1)).findById(id);
+        verify(clubMapper, times(1)).toDTO(club);
+        assertThat(result, is(dto));
+    }
+
+    @Test
+    void givenNonExistentClubIdWhenGetClubByIdThenThrowResourceNotFoundException() {
+        Long id = 1L;
+        when(clubRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> clubService.getClubById(id));
+    }
+
+    @Test
+    void givenPageableWhenGetAllClubsThenReturnPage() {
+        PageRequest pageable = PageRequest.of(0, 10);
+        Club club = mock(Club.class);
+        ClubResponseDTO dto = mock(ClubResponseDTO.class);
+        Page<Club> page = new PageImpl<>(Collections.singletonList(club), pageable, 1);
+
+        when(clubRepository.findAll(pageable)).thenReturn(page);
+        when(clubMapper.toDTO(club)).thenReturn(dto);
+
+        Page<ClubResponseDTO> result = clubService.getAllClubs(pageable);
+
+        assertThat(result.getContent().get(0), is(dto));
+    }
+}

--- a/src/test/java/com/oscar/football_api/service/ManagerServiceImplTest.java
+++ b/src/test/java/com/oscar/football_api/service/ManagerServiceImplTest.java
@@ -1,0 +1,98 @@
+package com.oscar.football_api.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import com.oscar.football_api.dto.ManagerRequestDTO;
+import com.oscar.football_api.dto.response.ManagerResponseDTO;
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.Manager;
+import com.oscar.football_api.exception.ConflictException;
+import com.oscar.football_api.exception.ResourceNotFoundException;
+import com.oscar.football_api.mapper.ManagerMapper;
+import com.oscar.football_api.repository.ClubRepository;
+import com.oscar.football_api.repository.ManagerRepository;
+import java.util.Optional;
+import com.oscar.football_api.service.impl.ManagerServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Collections;
+
+@ExtendWith(MockitoExtension.class)
+class ManagerServiceImplTest {
+
+    @InjectMocks private ManagerServiceImpl managerService;
+
+    @Mock private ManagerRepository managerRepository;
+    @Mock private ClubRepository clubRepository;
+    @Mock private ManagerMapper managerMapper;
+
+    @Test
+    void givenManagerRequestDTOWhenCreateManagerThenReturnDTO() {
+        ManagerRequestDTO requestDTO = new ManagerRequestDTO();
+        requestDTO.setClubId(1L);
+
+        Club club = mock(Club.class);
+        Manager manager = mock(Manager.class);
+        Manager saved = mock(Manager.class);
+        ManagerResponseDTO dto = mock(ManagerResponseDTO.class);
+
+        when(clubRepository.findById(1L)).thenReturn(Optional.of(club));
+        when(club.getManager()).thenReturn(null);
+        when(managerMapper.toEntity(requestDTO)).thenReturn(manager);
+        when(managerRepository.save(manager)).thenReturn(saved);
+        when(managerMapper.toDTO(saved)).thenReturn(dto);
+
+        ManagerResponseDTO result = managerService.createManager(requestDTO);
+
+        verify(clubRepository, times(1)).findById(1L);
+        verify(managerRepository, times(1)).save(manager);
+        verify(club, times(1)).setManager(saved);
+        assertThat(result, is(dto));
+    }
+
+    @Test
+    void givenNonExistentClubWhenCreateManagerThenThrowResourceNotFoundException() {
+        ManagerRequestDTO requestDTO = new ManagerRequestDTO();
+        requestDTO.setClubId(1L);
+
+        when(clubRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> managerService.createManager(requestDTO));
+    }
+
+    @Test
+    void givenClubWithManagerWhenCreateManagerThenThrowConflictException() {
+        ManagerRequestDTO requestDTO = new ManagerRequestDTO();
+        requestDTO.setClubId(1L);
+
+        Club club = mock(Club.class);
+        when(clubRepository.findById(1L)).thenReturn(Optional.of(club));
+        when(club.getManager()).thenReturn(mock(Manager.class));
+
+        assertThrows(ConflictException.class, () -> managerService.createManager(requestDTO));
+    }
+
+    @Test
+    void givenPageableWhenGetAllManagersThenReturnPage() {
+        PageRequest pageable = PageRequest.of(0, 10);
+        Manager manager = mock(Manager.class);
+        ManagerResponseDTO dto = mock(ManagerResponseDTO.class);
+        Page<Manager> page = new PageImpl<>(Collections.singletonList(manager), pageable, 1);
+
+        when(managerRepository.findAll(pageable)).thenReturn(page);
+        when(managerMapper.toDTO(manager)).thenReturn(dto);
+
+        Page<ManagerResponseDTO> result = managerService.getAllManagers(pageable);
+        assertThat(result.getContent().get(0), is(dto));
+    }
+}

--- a/src/test/java/com/oscar/football_api/service/PlayerServiceImplTest.java
+++ b/src/test/java/com/oscar/football_api/service/PlayerServiceImplTest.java
@@ -1,0 +1,101 @@
+package com.oscar.football_api.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import com.oscar.football_api.dto.PlayerRequestDTO;
+import com.oscar.football_api.dto.response.PlayerResponseDTO;
+import com.oscar.football_api.entity.Club;
+import com.oscar.football_api.entity.Player;
+import com.oscar.football_api.exception.ConflictException;
+import com.oscar.football_api.exception.ResourceNotFoundException;
+import com.oscar.football_api.mapper.PlayerMapper;
+import com.oscar.football_api.repository.ClubRepository;
+import com.oscar.football_api.repository.PlayerRepository;
+import java.util.Optional;
+import com.oscar.football_api.service.impl.PlayerServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Collections;
+
+@ExtendWith(MockitoExtension.class)
+class PlayerServiceImplTest {
+
+    @InjectMocks private PlayerServiceImpl playerService;
+
+    @Mock private PlayerRepository playerRepository;
+    @Mock private ClubRepository clubRepository;
+    @Mock private PlayerMapper playerMapper;
+
+    @Test
+    void givenPlayerRequestDTOWhenCreatePlayerThenReturnDTO() {
+        PlayerRequestDTO requestDTO = new PlayerRequestDTO();
+        requestDTO.setClubId(1L);
+        requestDTO.setJerseyNumber(10);
+
+        Club club = mock(Club.class);
+        Player player = mock(Player.class);
+        Player saved = mock(Player.class);
+        PlayerResponseDTO dto = mock(PlayerResponseDTO.class);
+
+        when(club.getId()).thenReturn(1L);
+        when(clubRepository.findById(1L)).thenReturn(Optional.of(club));
+        when(playerRepository.findByClubIdAndJerseyNumber(1L, 10)).thenReturn(Optional.empty());
+        when(playerMapper.toEntity(requestDTO)).thenReturn(player);
+        when(playerRepository.save(player)).thenReturn(saved);
+        when(playerMapper.toDTO(saved)).thenReturn(dto);
+
+        PlayerResponseDTO result = playerService.createPlayer(requestDTO);
+
+        verify(playerRepository, times(1)).save(player);
+        verify(playerMapper, times(1)).toEntity(requestDTO);
+        assertThat(result, is(dto));
+    }
+
+    @Test
+    void givenNonExistentClubWhenCreatePlayerThenThrowResourceNotFoundException() {
+        PlayerRequestDTO requestDTO = new PlayerRequestDTO();
+        requestDTO.setClubId(1L);
+
+        when(clubRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> playerService.createPlayer(requestDTO));
+    }
+
+    @Test
+    void givenDuplicateJerseyNumberWhenCreatePlayerThenThrowConflictException() {
+        PlayerRequestDTO requestDTO = new PlayerRequestDTO();
+        requestDTO.setClubId(1L);
+        requestDTO.setJerseyNumber(10);
+
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn(1L);
+        when(clubRepository.findById(1L)).thenReturn(Optional.of(club));
+        when(playerRepository.findByClubIdAndJerseyNumber(1L, 10)).thenReturn(Optional.of(mock(Player.class)));
+
+        assertThrows(ConflictException.class, () -> playerService.createPlayer(requestDTO));
+    }
+
+    @Test
+    void givenPageableWhenGetAllPlayersThenReturnPage() {
+        PageRequest pageable = PageRequest.of(0, 10);
+        Player player = mock(Player.class);
+        PlayerResponseDTO dto = mock(PlayerResponseDTO.class);
+        Page<Player> page = new PageImpl<>(Collections.singletonList(player), pageable, 1);
+
+        when(playerRepository.findAll(pageable)).thenReturn(page);
+        when(playerMapper.toDTO(player)).thenReturn(dto);
+
+        Page<PlayerResponseDTO> result = playerService.getAllPlayers(pageable);
+        assertThat(result.getContent().get(0), is(dto));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:football;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: sa
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:data.sql

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,35 @@
+INSERT INTO clubs (name, established_date, stadium_name, city, league, titles_won)
+VALUES
+  ('FC Barcelona', '1899-11-29', 'Spotify Camp Nou', 'Barcelona', 'LA_LIGA', 27),
+  ('Real Madrid CF', '1902-03-06', 'Santiago Bernabéu', 'Madrid', 'LA_LIGA', 36),
+  ('Atlético de Madrid', '1903-04-26', 'Cívitas Metropolitano', 'Madrid', 'LA_LIGA', 11);
+
+INSERT INTO managers (name, nationality, date_of_birth, titles_won, club_id)
+VALUES
+  ('Hansi Flick', 'German', '1965-02-24', 10, (SELECT id FROM clubs WHERE name = 'FC Barcelona')),
+  ('Carlo Ancelotti', 'Italian', '1959-06-10', 25, (SELECT id FROM clubs WHERE name = 'Real Madrid CF')),
+  ('Diego Simeone', 'Argentinian', '1970-04-28', 12, (SELECT id FROM clubs WHERE name = 'Atlético de Madrid'));
+
+INSERT INTO players (name, position, jersey_number, date_of_birth, nationality, club_id)
+VALUES
+  ('Marc-André ter Stegen', 'GOALKEEPER', 1, '1992-04-30', 'German', (SELECT id FROM clubs WHERE name = 'FC Barcelona')),
+  ('Ronald Araújo', 'DEFENDER', 4, '1999-03-07', 'Uruguayan', (SELECT id FROM clubs WHERE name = 'FC Barcelona')),
+  ('Frenkie de Jong', 'MIDFIELDER', 21, '1997-05-12', 'Dutch', (SELECT id FROM clubs WHERE name = 'FC Barcelona')),
+  ('Pedri', 'MIDFIELDER', 8, '2002-11-25', 'Spanish', (SELECT id FROM clubs WHERE name = 'FC Barcelona')),
+  ('Robert Lewandowski', 'FORWARD', 9, '1988-08-21', 'Polish', (SELECT id FROM clubs WHERE name = 'FC Barcelona'));
+
+INSERT INTO players (name, position, jersey_number, date_of_birth, nationality, club_id)
+VALUES
+  ('Thibaut Courtois', 'GOALKEEPER', 1, '1992-05-11', 'Belgian', (SELECT id FROM clubs WHERE name = 'Real Madrid CF')),
+  ('Éder Militão', 'DEFENDER', 3, '1998-01-18', 'Brazilian', (SELECT id FROM clubs WHERE name = 'Real Madrid CF')),
+  ('Luka Modrić', 'MIDFIELDER', 10, '1985-09-09', 'Croatian', (SELECT id FROM clubs WHERE name = 'Real Madrid CF')),
+  ('Jude Bellingham', 'MIDFIELDER', 5, '2003-06-29', 'English', (SELECT id FROM clubs WHERE name = 'Real Madrid CF')),
+  ('Vinícius Jr.', 'FORWARD', 7, '2000-07-12', 'Brazilian', (SELECT id FROM clubs WHERE name = 'Real Madrid CF'));
+
+INSERT INTO players (name, position, jersey_number, date_of_birth, nationality, club_id)
+VALUES
+  ('Jan Oblak', 'GOALKEEPER', 13, '1993-01-07', 'Slovenian', (SELECT id FROM clubs WHERE name = 'Atlético de Madrid')),
+  ('José María Giménez', 'DEFENDER', 2, '1995-01-20', 'Uruguayan', (SELECT id FROM clubs WHERE name = 'Atlético de Madrid')),
+  ('Koke', 'MIDFIELDER', 6, '1992-01-08', 'Spanish', (SELECT id FROM clubs WHERE name = 'Atlético de Madrid')),
+  ('Rodrigo de Paul', 'MIDFIELDER', 5, '1994-05-24', 'Argentinian', (SELECT id FROM clubs WHERE name = 'Atlético de Madrid')),
+  ('Álvaro Morata', 'FORWARD', 9, '1992-10-23', 'Spanish', (SELECT id FROM clubs WHERE name = 'Atlético de Madrid'));


### PR DESCRIPTION
This PR adds comprehensive test coverage across the main layers of the application. It includes:

- **Service Layer:** Unit tests using JUnit + Mockito for PlayerService, ClubService, and ManagerService.
- **Controller Layer:** Integration tests using @WebMvcTest + MockMvc for PlayerController, ClubController, and ManagerController. Dependencies are mocked with @MockBean.
- **Repository Layer:** Integration tests using @DataJpaTest with H2 in-memory database for custom queries.
- **Mappers:** Unit tests for PlayerMapper, ClubMapper, and ManagerMapper.
- Test infrastructure includes application-test.yml, sample data.sql, H2 dependency, and @ActiveProfiles("test") in the main application.

This PR ensures correctness, maintainability, and robustness of the codebase.

Closes: #22 