### PR TITLE
Fix environment variable management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,10 @@
-# Variables for Docker Compose
-POSTGRES_DB=<db_name>
-POSTGRES_USER=<user>
-POSTGRES_PASSWORD=<password>
+# Database configuration
+DB_NAME=<db_name>
+DB_USER=<user>
+DB_PASSWORD=<password>
+DB_HOST=<db_host>
+DB_PORT=<db_port>
 
-# Variables for local development (optional)
-DB_NAME=<local_db_name>
-DB_USER=<local_user>
-DB_PASSWORD=<local_password>
-DB_HOST=<local_host>
-DB_PORT=<local_port>
-
-# Variables for authentication
-ADMIN_USERNAME=<admin_name>
+# Admin credentials
+ADMIN_USERNAME=<admin_username>
 ADMIN_PASSWORD=<admin_password>

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ target/
 !**/src/main/**/target/
 !**/src/test/**/target/
 .env
-.env.local
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -1,34 +1,36 @@
 # Football API - Spring Boot 3.5.5 + Java 21 + Docker
 
-RESTful API for managing football clubs, players, and managers, built with Spring Boot 3.5.5, Java 21, and PostgreSQL.  
-The API is fully dockerized and ready for technical testing or local development.
+
+RESTful API for managing football clubs, players, and managers — built with **Spring Boot 3.5.5**, **Java 21**, and **PostgreSQL**.  
+The project is fully **dockerized**, so you can run it instantly for local development or technical testing.
 
 ---
 
 1. [Requirements](#1-requirements)
 2. [Environment Variables](#2-environment-variables)
 3. [Running the Project](#3-running-the-project)
-    - [Using Docker (recommended)](#a-using-docker-recommended-for-the-technical-test)
-    - [Local Development](#b-local-development-without-docker)
-4. [Important Notes](#4-important-notes)
-5. [Useful Commands](#5-useful-commands)
-6. [Example API Usage (Swagger)](#6-example-api-usage-swagger)
-7. [Recommended Workflow](#7-recommended-workflow)
+    - [Using Docker (recommended)](#a-using-docker-recommended)
+    - [Local Development (without Docker)](#b-local-development-without-docker)
+4. [Authentication](#4-authentication)
+5. [Project Notes](#5-project-notes)
+6. [Useful Commands](#6-useful-commands)
+7. [Swagger API Docs](#7-swagger-api-docs)
+8. [Recommended Workflow](#8-recommended-workflow)
 
 ---
 
 ## 1. Requirements
 
-- Docker 24+
-- Docker Compose 2+
-- Java 21 (only for local development, not required with Docker)
-- Maven (only for local development, not required with Docker)
+- **Docker** ≥ 24
+- **Docker Compose** ≥ 2
+- **Java 21** (only if running locally)
+- **Maven** (only if running locally)
 
 ---
 
 ## 2. Environment Variables
 
-### `.env` (Docker Compose)
+### `.env` (used by Docker Compose)
 ```bash
   POSTGRES_DB=api_football_db
   POSTGRES_USER=postgres
@@ -36,71 +38,73 @@ The API is fully dockerized and ready for technical testing or local development
   
   ADMIN_USERNAME=admin
   ADMIN_PASSWORD=password
-````
-
-### `.env.local` (Local Development)
-```bash
-  DB_NAME=api_football_db
-  DB_USER=postgres
-  DB_PASSWORD=postgres
-  DB_HOST=localhost
-  DB_PORT=5432
-  
-  ADMIN_USERNAME=admin
-  ADMIN_PASSWORD=password
 ```
 
 ### `.env.example`
-- Contains placeholders for the variables above, explaining which ones are for Docker and which ones for local development.
-- This file can be committed to the repository so others know which variables to configure.
-
-### Authentication (required for secured endpoints)
-- Both Docker and local development require admin credentials to be set via environment variables:
-
-```bash
-  ADMIN_USERNAME=admin
-  ADMIN_PASSWORD=password
-```
-- These values will be injected into the application at runtime.
-- They are required for performing POST, PUT, or DELETE requests.
+- Serves as a public template for required environment variables.
+- Copy it before running the project.
+> Note: ⚠️ .env is not committed to Git — it holds your private configuration.
 
 ---
 
 ## 3. Running the Project
 
-### A. Using Docker (recommended for the technical test)
+### A. Using Docker (recommended)
 
+- Copy the environment file:
 ```bash
-  docker-compose build
-  docker-compose up -d
+   cp .env.example .env
+```
+
+- Edit .env and replace the placeholders (<db_name>, <user>, <password>, etc.) with your actual environment values.
+
+- Build and start the containers:
+```bash
+  docker-compose up -d --build
 ```
 - Wait until the PostgreSQL container passes its healthcheck.
+
 - View application logs:
 ```bash
   docker-compose logs -f app
 ```
 - Swagger UI is available at: http://localhost:8080/swagger-ui/index.html
-- PostgreSQL database can be accessed at `localhost:5432` (user: postgres / password: postgres / db: api_football_db).
+- PostgreSQL database can be accessed at `localhost:5432`.
+  - user: `postgres`
+  - password: `postgres`
+  - db: `api_football_db`
+
 - To stop the containers:
 ```bash
   docker-compose down
 ```
+
 - To restart fresh (no persistence; `data.sql` will be executed again):
 ```bash
   docker-compose up -d --build
 ```
 
 ### B. Local Development (without Docker)
-1. Create `.env.local` with your local credentials.
-2. Run the application from IntelliJ or using Maven:
+- Ensure PostgreSQL is running locally.
+- Add your environment variables directly in IntelliJ:
+```bash
+  DB_NAME=api_football_db
+  DB_USER=postgres
+  DB_PASSWORD=postgres
+  DB_HOST=localhost
+  DB_PORT=5432
+  ADMIN_USERNAME=admin
+  ADMIN_PASSWORD=admin123
+```
+- Run the application:
 ```bash
   mvn spring-boot:run
 ```
-3. Swagger UI: http://localhost:8080/swagger-ui/index.html
-4. PostgreSQL database should match the settings in `.env.local`.
+- Swagger UI is available at: http://localhost:8080/swagger-ui/index.html
 
+---
 
-### Authentication
+### 4. Authentication
 
 - All `GET /api/v1/**` endpoints are public and can be tested without authentication.
 - `POST`, `PUT`, and `DELETE` requests require authentication with the admin credentials.
@@ -110,19 +114,21 @@ Default credentials (if configured in `.env`):
 - Username: `admin`
 - Password: `password`
 
----
-
-### 4. Important Notes
-
-- **Multi-stage Dockerfile:** Builds the project with Maven and creates a lightweight runtime image containing only the JAR.
-- **Docker Compose:** Starts the API and PostgreSQL; the application waits for the database to be ready before starting.
-- **Data persistence:** No persistent volume in Docker, so each startup runs data.sql to populate the database from scratch.
-- **Best practices:** `.env` and `.env.local` are ignored by Git; `.env.example` serves as a guide for required variables.
-- **Authentication:** Admin credentials are required for modifying resources. Make sure `ADMIN_USERNAME` and `ADMIN_PASSWORD` are configured in `.env` or `.env.local`.
+>In Swagger UI, click Authorize and enter these credentials to test secured endpoints.
 
 ---
 
-### 5. Useful Commands
+### 5. Project Notes
+
+- **Multi-stage Dockerfile →** Builds and runs lightweight JAR image.
+- **Docker Compose →** Starts app + PostgreSQL with proper dependency checks.
+- **data.sql** auto-loads demo data each time containers start (no persistence).
+- **Authentication →** Admin credentials injected via environment variables.
+- **.env.example →** Template for required environment variables.
+
+---
+
+### 6. Useful Commands
 
 ```bash
 # Build and start containers
@@ -137,26 +143,26 @@ Default credentials (if configured in `.env`):
 
 ---
 
-### 6. Example API Usage (Swagger)
+### 7. Swagger API Docs
 
 Once the application is running, you can explore and test all endpoints via Swagger UI:
 
-- **URL:** http://localhost:8080/swagger-ui.html
+- **URL:** http://localhost:8080/swagger-ui/index.html
 - **Example endpoints:**
 
-    - `/api/clubs` → CRUD operations for clubs
-    - `/api/players` → CRUD operations for players
-    - `/api/managers` → CRUD operations for managers
+    - `/api/v1/clubs` → CRUD operations for clubs
+    - `/api/v1/players` → CRUD operations for players
+    - `/api/v1/managers` → CRUD operations for managers
 
 > ⚠️ Note: In Swagger UI, click on the **Authorize** button and enter your admin username/password to test secured endpoints (POST, PUT, DELETE).
 
 ---
 
-### 7. Recommended Workflow
+### 8. Recommended Workflow
 
 - **For technical test (Docker):** just run `docker-compose up -d --build` and test via Swagger or Postman.
-- **For local development:** create `.env.local`, run with Maven or IntelliJ, and the API will connect to your local PostgreSQL.
+- **For local development:** Start PostgreSQL locally, set .env, and run `mvn spring-boot:run`.
 
 ---
 
-This setup ensures that the project works out-of-the-box for reviewers and developers, either in a **dockerized environment** or **local development**, following professional standards.
+With this setup, the project is **ready to run anywhere** — either fully dockerized or locally — following best practices for Spring Boot apps.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,14 @@ services:
     image: postgres:16
     container_name: football_db
     env_file: .env
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -22,11 +26,10 @@ services:
       db:
         condition: service_healthy
     environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/${POSTGRES_DB}
-      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
-      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
-      SPRING_JPA_HIBERNATE_DDL_AUTO: update
-      SPRING_SQL_INIT_MODE: always
-
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
       ADMIN_USERNAME: ${ADMIN_USERNAME}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}

--- a/pom.xml
+++ b/pom.xml
@@ -100,13 +100,6 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <!-- Environment variables -->
-        <dependency>
-            <groupId>me.paulschwarz</groupId>
-            <artifactId>spring-dotenv</artifactId>
-            <version>4.0.0</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This PR removes the deprecated spring-dotenv dependency and refactors environment variable management to use native Spring Boot support.

**Changes included:**
- Removed `spring-dotenv` from `pom.xml`.
- Configured Spring Boot to read environment variables natively from the system or Docker.
- Updated docker-compose.yml to use unified DB_* variables.
- Cleaned up environment files: removed .env.local, kept .env for local/Docker, and updated .env.example with placeholders.
- Updated README.md to reflect new environment variable usage, instructions for Docker and local development, and Swagger API access.

This ensures a secure and maintainable way to handle environment variables, while keeping the project ready-to-run for both technical tests and local development.

Closes #24 